### PR TITLE
chore: provider and config cleanup 

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,6 @@ mangarr download -d ./downloads -s "mangaplus" -m "100037" -C "6,17"
 # Download the latest chapter of Solo Leveling: Ragnarok from Flame Comics
 mangarr download -d ./downloads -s "flamecomics" -m "https://flamecomics.xyz/series/solo-leveling-ragnarok/"
 
-# Download the latest chapter of Solo Max-Level Newbie from Asura Scans
-mangarr download -d ./downloads -s "asurascans" -m "https://asuracomic.net/series/solo-max-level-newbie-31f980f5"
-
 # Download chapter 1-3 of One Punch Man from Cubari
 mangarr download -d ./downloads -s "cubari" -m "https://git.io/OPM" -g "/r/OnePunchMan" -C "1-3"
 

--- a/cmd/download.go
+++ b/cmd/download.go
@@ -44,8 +44,8 @@ var downloadCmd = &cobra.Command{
 			s = source.NewMangaPlus(manga)
 		case "flamecomics":
 			s = source.NewFlamecomics(manga)
-		case "asurascans":
-			s = source.NewAsurascans(manga)
+		//case "asurascans":
+		//	s = source.NewAsurascans(manga)
 		case "cubari":
 			s = source.NewCubari(manga, group)
 		default:
@@ -129,7 +129,7 @@ var downloadCmd = &cobra.Command{
 				}
 
 				fmt.Printf("Downloading %q...\n", templatedName)
-				if err := download.Chapter(ctx, contentPath, selectedChapter); err != nil {
+				if err := download.Chapter(ctx, contentPath, selectedChapter, selectedManga.IsManhwa); err != nil {
 					fmt.Printf("Failed to download chapter %q: %v\n", templatedName, err)
 					return
 				}

--- a/cmd/monitor.go
+++ b/cmd/monitor.go
@@ -59,8 +59,8 @@ var monitorCmd = &cobra.Command{
 				sources = append(sources, source.NewMangaPlus(monitoredManga.Manga))
 			case "flamecomics":
 				sources = append(sources, source.NewFlamecomics(monitoredManga.Manga))
-			case "asurascans":
-				sources = append(sources, source.NewAsurascans(monitoredManga.Manga))
+			//case "asurascans":
+			//	sources = append(sources, source.NewAsurascans(monitoredManga.Manga))
 			case "cubari":
 				sources = append(sources, source.NewCubari(monitoredManga.Manga, monitoredManga.Group))
 			default:
@@ -149,7 +149,7 @@ var monitorCmd = &cobra.Command{
 							}
 
 							mLog.Info().Msgf("downloading %q", templatedName)
-							if err := download.Chapter(ctx, contentPath, selectedChapter); err != nil {
+							if err := download.Chapter(ctx, contentPath, selectedChapter, selectedManga.IsManhwa); err != nil {
 								mLog.Error().Err(err).Msgf("error downloading chapter %s", templatedName)
 								return
 							}

--- a/cmd/monitor.go
+++ b/cmd/monitor.go
@@ -71,7 +71,7 @@ var monitorCmd = &cobra.Command{
 
 		log.Info().Msg("starting to monitor configured manga")
 
-		ticker := time.NewTicker(time.Duration(cfg.Config.CheckInterval)*time.Minute - 40*time.Second)
+		ticker := time.NewTicker(time.Duration(cfg.Config.CheckInterval) * time.Minute)
 		defer ticker.Stop()
 
 		// semaphore to limit concurrency to 10

--- a/config.yaml
+++ b/config.yaml
@@ -79,17 +79,6 @@ monitoredManga:
 
   # Custom name you can give the entry to easily distinguish between them
   #
-  Solo Max-Level Newbie:
-    # Source from where the manga should be downloaded
-    #
-    source: "asurascans"
-
-    # URL of the manga on Asura Scans
-    #
-    manga: "https://asuracomic.net/series/solo-max-level-newbie-31f980f5"
-
-  # Custom name you can give the entry to easily distinguish between them
-  #
   One Punch Man:
     # Source from where the manga should be downloaded
     #

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -291,9 +291,17 @@ func (c *AppConfig) load(configPath string) {
 func (c *AppConfig) DynamicReload(log logger.Logger) {
 	viper.WatchConfig()
 
-	viper.OnConfigChange(func(_ fsnotify.Event) {
+	viper.OnConfigChange(func(e fsnotify.Event) {
 		c.m.Lock()
 		defer c.m.Unlock()
+
+		// only reload config on write to config file
+		if !e.Op.Has(fsnotify.Write) {
+			return
+		}
+
+		namingTemplate := viper.GetString("namingTemplate")
+		c.Config.NamingTemplate = namingTemplate
 
 		logLevel := viper.GetString("logLevel")
 		c.Config.LogLevel = logLevel

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -99,17 +99,6 @@ monitoredManga:
 
   # Custom name you can give the entry to easily distinguish between them
   #
-  Solo Max-Level Newbie:
-    # Source from where the manga should be downloaded
-    #
-    source: "asurascans"
-
-    # URL of the manga on Asura Scans
-    #
-    manga: "https://asuracomic.net/series/solo-max-level-newbie-31f980f5"
-
-  # Custom name you can give the entry to easily distinguish between them
-  #
   One Punch Man:
     # Source from where the manga should be downloaded
     #

--- a/internal/domain/provider.go
+++ b/internal/domain/provider.go
@@ -14,6 +14,7 @@ type Manga struct {
 	URL      string
 	Title    string
 	Chapters map[float32]Chapter
+	IsManhwa bool
 }
 
 type Chapter struct {
@@ -21,13 +22,10 @@ type Chapter struct {
 	URL       string
 	Number    float32
 	Title     string
-	IsManhwa  bool
 	ImageInfo []ImageInfo
 }
 
 type ImageInfo struct {
 	ImageURL      string
 	EncryptionKey string
-	Width         float64
-	Height        float64
 }

--- a/internal/download/download.go
+++ b/internal/download/download.go
@@ -24,7 +24,7 @@ import (
 const maxConcurrentImageDownloads = 10
 
 // Chapter downloads and processes manga chapter images to create a CBZ archive.
-func Chapter(ctx context.Context, contentPath string, chapter domain.Chapter) error {
+func Chapter(ctx context.Context, contentPath string, chapter domain.Chapter, isManhwa bool) error {
 	// if chapter.IsManhwa {
 	// 	 outputPath = contentPath + ".pdf"
 	// } else {
@@ -92,7 +92,7 @@ func Chapter(ctx context.Context, contentPath string, chapter domain.Chapter) er
 	// 	 }
 	// }
 
-	if err := files.CreateCbzArchive(temp, contentPath, chapter.IsManhwa); err != nil {
+	if err := files.CreateCbzArchive(temp, contentPath, isManhwa); err != nil {
 		return fmt.Errorf("failed to create cbz archive: %w", err)
 	}
 

--- a/internal/source/asurascans.go
+++ b/internal/source/asurascans.go
@@ -53,9 +53,12 @@ func (a *asurascans) ValidateInput() error {
 }
 
 func (a *asurascans) GetManga(_ context.Context) (domain.Manga, error) {
-	var manga domain.Manga
 	var errors []error
-	manga.Chapters = make(map[float32]domain.Chapter)
+
+	manga := domain.Manga{
+		Chapters: make(map[float32]domain.Chapter),
+		IsManhwa: true,
+	}
 
 	c := a.Collector.Clone()
 
@@ -68,19 +71,21 @@ func (a *asurascans) GetManga(_ context.Context) (domain.Manga, error) {
 	})
 
 	c.OnHTML(".pl-4.pr-2.pb-4 a", func(e *colly.HTMLElement) {
-		chapterNum, chapterTitle, err := a.splitChapterInfo(e.Text)
+		chapterTitle := e.ChildText("span")
+
+		chapterNum, err := a.splitChapterInfo(e.Text, chapterTitle)
 		if err != nil {
 			errors = append(errors, fmt.Errorf("failed to parse chapter info %q from URL %s: %w", e.Text, e.Request.URL, err))
 			return
 		}
 
 		chapterURL := e.Attr("href")
+		chapterTitle = sanitize.Filename(chapterTitle)
 
 		manga.Chapters[chapterNum] = domain.Chapter{
-			URL:      chapterURL,
-			Number:   chapterNum,
-			Title:    chapterTitle,
-			IsManhwa: true,
+			URL:    chapterURL,
+			Number: chapterNum,
+			Title:  chapterTitle,
 		}
 	})
 
@@ -144,17 +149,26 @@ func (a *asurascans) GetImageURLs(_ context.Context, chapter *domain.Chapter) er
 	return nil
 }
 
-func (a *asurascans) splitChapterInfo(input string) (float32, string, error) {
-	parts := strings.SplitN(input, " ", 3)
-	chapterNumberStr := parts[1]
+func (a *asurascans) splitChapterInfo(chapterLine string, chapterTitle string) (float32, error) {
+	cutChapterLine := chapterLine
 
-	chapterNumber, err := strconv.ParseFloat(chapterNumberStr, 32)
-	if err != nil {
-		return 0, "", fmt.Errorf("failed to parse chapter number from %s: %w", chapterNumberStr, err)
+	if len(chapterTitle) != 0 {
+		// not checking for found, because if chapterTitle is not found in chapterLine, cutChapterLine will be set
+		// to chapterLine which already is in the format "Chapter Number"
+		cutChapterLine, _, _ = strings.Cut(chapterLine, chapterTitle)
 	}
 
-	chapterTitle := strings.TrimSpace(strings.Join(parts[2:], " "))
+	_, cutChapterLine, ok := strings.Cut(cutChapterLine, "Chapter ")
+	if !ok {
+		return 0, fmt.Errorf("failed to split chapter string %q", cutChapterLine)
+	}
+
+	chapterNumber, err := strconv.ParseFloat(cutChapterLine, 32)
+	if err != nil {
+		return 0, fmt.Errorf("failed to parse chapter number from %s: %w", cutChapterLine, err)
+	}
+
 	chapterTitle = sanitize.Filename(chapterTitle)
 
-	return float32(chapterNumber), chapterTitle, nil
+	return float32(chapterNumber), nil
 }

--- a/internal/source/flamecomics.go
+++ b/internal/source/flamecomics.go
@@ -51,9 +51,12 @@ func (f *flamecomics) ValidateInput() error {
 }
 
 func (f *flamecomics) GetManga(_ context.Context) (domain.Manga, error) {
-	var manga domain.Manga
 	var errors []error
-	manga.Chapters = make(map[float32]domain.Chapter)
+
+	manga := domain.Manga{
+		Chapters: make(map[float32]domain.Chapter),
+		IsManhwa: true,
+	}
 
 	c := f.Collector.Clone()
 
@@ -76,9 +79,8 @@ func (f *flamecomics) GetManga(_ context.Context) (domain.Manga, error) {
 		chapterNum := float32(chapterNum64)
 
 		manga.Chapters[chapterNum] = domain.Chapter{
-			URL:      chapterURL,
-			Number:   chapterNum,
-			IsManhwa: true,
+			URL:    chapterURL,
+			Number: chapterNum,
 		}
 	})
 

--- a/internal/source/mangadex.go
+++ b/internal/source/mangadex.go
@@ -19,8 +19,12 @@ import (
 )
 
 const (
-	mangadexURL   = "https://api.mangadex.org"
-	mangadexLimit = 500
+	mangadexURL         = "https://api.mangadex.org"
+	mangadexResultLimit = 500
+
+	// tag ID for the "Long Strip" format to identify Manhwa
+	// https://mangadex.org/titles?include=3e2b8dae-350e-4ab8-a8ce-016e844b9f0d
+	mangadexLongStripTagID = "3e2b8dae-350e-4ab8-a8ce-016e844b9f0d"
 )
 
 type mangadex struct {
@@ -33,11 +37,13 @@ type mangadex struct {
 type mangadexManga struct {
 	Data struct {
 		ID         string `json:"id"`
-		Type       string `json:"type"`
 		Attributes struct {
 			Title struct {
 				En string `json:"en"`
 			} `json:"title"`
+			Tags []struct {
+				ID string `json:"id"`
+			} `json:"tags"`
 		} `json:"attributes"`
 	} `json:"data"`
 }
@@ -49,7 +55,6 @@ type mangadexChapters struct {
 
 type mangadexChaptersData struct {
 	ID         string `json:"id"`
-	Type       string `json:"type"`
 	Attributes struct {
 		Volume  *string `json:"volume"`
 		Chapter string  `json:"chapter"`
@@ -64,9 +69,8 @@ type mangadexChaptersData struct {
 type mangadexChapter struct {
 	BaseURL string `json:"baseUrl"`
 	Chapter struct {
-		Hash      string   `json:"hash"`
-		Data      []string `json:"data"`
-		DataSaver []string `json:"dataSaver"`
+		Hash string   `json:"hash"`
+		Data []string `json:"data"`
 	} `json:"chapter"`
 }
 
@@ -106,6 +110,7 @@ func (m *mangadex) ValidateInput() error {
 
 func (m *mangadex) GetManga(ctx context.Context) (domain.Manga, error) {
 	var mangaResp mangadexManga
+	var isManhwa bool
 
 	path, err := url.JoinPath(mangadexURL, "manga", m.MangaID)
 	if err != nil {
@@ -147,9 +152,17 @@ func (m *mangadex) GetManga(ctx context.Context) (domain.Manga, error) {
 		return domain.Manga{}, fmt.Errorf("failed to get manga for ID %s", m.MangaID)
 	}
 
+	for _, tag := range mangaResp.Data.Attributes.Tags {
+		if tag.ID == mangadexLongStripTagID {
+			isManhwa = true
+			break
+		}
+	}
+
 	return domain.Manga{
 		Title:    sanitize.Filename(title),
 		Chapters: make(map[float32]domain.Chapter),
+		IsManhwa: isManhwa,
 	}, nil
 }
 
@@ -174,7 +187,7 @@ func (m *mangadex) GetChapters(ctx context.Context, manga domain.Manga) error {
 			"translatedLanguage[]": []string{m.Language},
 			"order[volume]":        []string{"desc"},
 			"order[chapter]":       []string{"desc"},
-			"limit":                []string{fmt.Sprintf("%d", mangadexLimit)},
+			"limit":                []string{fmt.Sprintf("%d", mangadexResultLimit)},
 			"offset":               []string{fmt.Sprintf("%d", offset)},
 		}
 
@@ -238,7 +251,7 @@ func (m *mangadex) GetChapters(ctx context.Context, manga domain.Manga) error {
 			return nil
 		}
 
-		offset += mangadexLimit
+		offset += mangadexResultLimit
 	}
 }
 


### PR DESCRIPTION
Disable `Asura Scans` for the time being, adds Manhwa support for `MangaDex` and fixes an issue with dynamic config reloads being logged twice.