### PR TITLE
fix(weebcentral): switch image extraction to http

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # ARCHITECTURE.md
 
-Verified against code on 2026-03-22.
+Verified against code on 2026-03-25.
 
 ## Purpose
 
@@ -66,8 +66,8 @@ Rule: source-specific scraping logic stays in `internal/source/`. Generic retry,
   - retries transport failures and `500/502/503/504`
   - fails fast on `404/429/401/403/405`
 - Browser-backed sources:
-  - `weebcentral`
-  - shared lifecycle in `internal/browser/`
+  - none currently
+  - shared lifecycle in `internal/browser/` remains available for future JS-heavy sources
 
 ## Hotspots
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Mangarr currently supports downloading from **8 different manga sources**:
 | [Flame Comics](https://flamecomics.xyz/) | `flamecomics` | Requires full manga URL |
 | [Asura Scans](https://asurascans.com/) | `asurascans` | Requires a current `https://asurascans.com/comics/...` series URL |
 | [Cubari](https://cubari.moe/) | `cubari` | Requires gist URL and group identifier |
-| [Weeb Central](https://weebcentral.com/) | `weebcentral` | Requires manga identifier, uses browser automation |
+| [Weeb Central](https://weebcentral.com/) | `weebcentral` | Requires manga identifier, uses direct HTML image extraction |
 | [Comix](https://comix-online.org/) | `comix` | Requires manga identifier and group |
 
 ## Installation

--- a/cmd/download.go
+++ b/cmd/download.go
@@ -8,7 +8,6 @@ import (
 	"sync"
 	"time"
 
-	"mangarr/internal/browser"
 	"mangarr/internal/domain"
 	"mangarr/internal/download"
 	"mangarr/internal/files"
@@ -42,9 +41,6 @@ var downloadCmd = &cobra.Command{
 
 		var s domain.Source
 
-		bm := browser.NewManager()
-		defer bm.Close()
-
 		switch mangaSource {
 		case "tcbscans":
 			s = source.NewTCBScans(manga)
@@ -59,7 +55,7 @@ var downloadCmd = &cobra.Command{
 		case "cubari":
 			s = source.NewCubari(manga, group)
 		case "weebcentral":
-			s = source.NewWeebCentral(manga, bm)
+			s = source.NewWeebCentral(manga)
 		case "comix":
 			s = source.NewComix(manga, group)
 		default:

--- a/cmd/monitor.go
+++ b/cmd/monitor.go
@@ -10,7 +10,6 @@ import (
 	"syscall"
 	"time"
 
-	"mangarr/internal/browser"
 	"mangarr/internal/buildinfo"
 	"mangarr/internal/config"
 	"mangarr/internal/download"
@@ -68,8 +67,6 @@ var monitorCmd = &cobra.Command{
 		ticker := time.NewTicker(cfg.Config.CheckInterval * time.Minute)
 		defer ticker.Stop()
 
-		bm := browser.NewManager()
-
 		// semaphore to limit concurrency to maxConcurrentSourceProcesses which is set to 10
 		sem := semaphore.NewWeighted(maxConcurrentSourceProcesses)
 		quit := make(chan bool, 1)
@@ -86,7 +83,7 @@ var monitorCmd = &cobra.Command{
 							sem.Acquire()
 							defer sem.Release()
 
-							mangaSource, err := source.Select(*monitoredManga, bm)
+							mangaSource, err := source.Select(*monitoredManga)
 							if err != nil {
 								log.Error().Err(err).Msgf("error selecting manga source")
 								return
@@ -166,6 +163,5 @@ var monitorCmd = &cobra.Command{
 		cancel()
 		quit <- true
 		wg.Wait()
-		bm.Close()
 	},
 }

--- a/docs/design-docs/source-adapters.md
+++ b/docs/design-docs/source-adapters.md
@@ -1,6 +1,6 @@
 # Source Adapters
 
-Verified against `internal/source/` on 2026-03-22.
+Verified against `internal/source/` on 2026-03-25.
 
 All adapters implement `domain.Source`.
 
@@ -14,7 +14,7 @@ All adapters implement `domain.Source`.
 | `flamecomics` | full series URL | none | `https://flamecomics.xyz` prefix | HTML + embedded JSON |
 | `asurascans` | full series URL | none | `https://asurascans.com/comics/...` | server-rendered HTML |
 | `cubari` | gist URL | `-g` required | valid URL + non-empty group | images resolved in payload |
-| `weebcentral` | full series URL | none | `https://weebcentral.com` prefix | scraper + browser extraction |
+| `weebcentral` | full series URL | none | `https://weebcentral.com` prefix | scraper + chapter image fragment fetch |
 | `comix` | full title URL | `-g` optional | `https://comix.to/title` prefix | API-based |
 
 ## Rules
@@ -28,6 +28,6 @@ All adapters implement `domain.Source`.
 ## Shared Behavior
 
 - unknown source values fail fast in source selection
-- `weebcentral` uses `internal/browser.Manager`
+- `weebcentral` fetches chapter images from the `/chapters/<id>/images` HTML fragment
 - retry policy comes from `internal/sharedhttp/`
 - manhwa/long-strip handling flows through `selectedManga.IsManhwa`

--- a/docs/exec-plans/completed/2026-03-25-weebcentral-http-image-extraction.md
+++ b/docs/exec-plans/completed/2026-03-25-weebcentral-http-image-extraction.md
@@ -1,0 +1,47 @@
+# Weeb Central HTTP Image Extraction
+
+Status: completed on 2026-03-25.
+
+## Problem
+
+`weebcentral` chapter downloads were failing with `waiting for image page load: context deadline exceeded` because the adapter waited on the reader shell while chapter images arrived through a separate htmx fragment request.
+
+## Scope
+
+- replace browser-backed chapter image extraction with direct HTTP against the current chapter image fragment endpoint
+- add regression coverage for the URL-construction and image extraction seam
+- update docs that describe current adapter behavior
+
+## Non-Goals
+
+- browser package removal
+- wider download/monitor orchestration cleanup
+
+## Decisions
+
+- keep `NewWeebCentral(...)` stable to avoid unrelated call-site churn
+- fetch `/chapters/<id>/images?is_prev=False&current_page=1&reading_style=long_strip` directly
+- parse returned HTML for ordered `img[src]` values and dedupe duplicates
+
+## Progress Log
+
+- confirmed live reader HTML loads image content through an htmx `/images` fragment
+- confirmed the fragment is public and returns direct `<img src="...">` elements
+- replaced rod/stealth image extraction with direct HTTP fragment fetching
+- removed now-dead browser-manager plumbing from Weeb Central constructor/call sites
+- added focused regression tests for query construction, query stripping, duplicate removal, and empty fragments
+- updated source-behavior docs to match the new adapter path
+
+## Verification
+
+- `gofumpt -w internal/source/weebcentral.go internal/source/weebcentral_test.go`
+- `go test ./internal/source/...`
+- `go test ./...`
+- `go test -race ./...`
+- `go build ./...`
+- `mkdir -p /tmp/mangarr-weebcentral-smoke`
+- `go run . download -d /tmp/mangarr-weebcentral-smoke -s weebcentral -m https://weebcentral.com/series/01J76XYD7E91K8QP6CY0Y53900 -L`
+
+## Follow-Up
+
+- `internal/browser/` remains available in the repo for future JS-heavy sources, but no current adapter depends on it

--- a/internal/source/source.go
+++ b/internal/source/source.go
@@ -3,11 +3,10 @@ package source
 import (
 	"fmt"
 
-	"mangarr/internal/browser"
 	"mangarr/internal/domain"
 )
 
-func Select(monitoredManga domain.MonitoredManga, bm *browser.Manager) (domain.Source, error) {
+func Select(monitoredManga domain.MonitoredManga) (domain.Source, error) {
 	switch monitoredManga.Source {
 	case "tcbscans":
 		return NewTCBScans(monitoredManga.Manga), nil
@@ -22,7 +21,7 @@ func Select(monitoredManga domain.MonitoredManga, bm *browser.Manager) (domain.S
 	case "cubari":
 		return NewCubari(monitoredManga.Manga, monitoredManga.Group), nil
 	case "weebcentral":
-		return NewWeebCentral(monitoredManga.Manga, bm), nil
+		return NewWeebCentral(monitoredManga.Manga), nil
 	case "comix":
 		return NewComix(monitoredManga.Manga, monitoredManga.Group), nil
 	}

--- a/internal/source/weebcentral.go
+++ b/internal/source/weebcentral.go
@@ -1,18 +1,22 @@
 package source
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"io"
+	"net/http"
 	"net/url"
 	"regexp"
 	"strings"
 	"time"
 
-	"mangarr/internal/browser"
 	"mangarr/internal/domain"
 	"mangarr/internal/sanitize"
+	"mangarr/internal/sharedhttp"
 
-	"github.com/go-rod/stealth"
+	"github.com/PuerkitoBio/goquery"
+	"github.com/avast/retry-go"
 	"github.com/gocolly/colly"
 	"github.com/gocolly/colly/extensions"
 )
@@ -25,11 +29,12 @@ var weebcentralChapterNumberPattern = regexp.MustCompile(`(?:Chapter|Ch.) ?(\d+(
 
 type weebcentral struct {
 	MangaURL  string
-	Browser   *browser.Manager
 	Collector colly.Collector
+	Client    http.Client
+	BaseURL   string
 }
 
-func NewWeebCentral(mangaURL string, bm *browser.Manager) domain.Source {
+func NewWeebCentral(mangaURL string) domain.Source {
 	collector := colly.NewCollector(
 		colly.AllowURLRevisit(),
 	)
@@ -39,8 +44,12 @@ func NewWeebCentral(mangaURL string, bm *browser.Manager) domain.Source {
 
 	return &weebcentral{
 		Collector: *collector,
-		Browser:   bm,
 		MangaURL:  mangaURL,
+		BaseURL:   weebcentralURL,
+		Client: http.Client{
+			Timeout:   120 * time.Second,
+			Transport: sharedhttp.Transport,
+		},
 	}
 }
 
@@ -139,37 +148,20 @@ func (w *weebcentral) GetChapters(_ context.Context, manga domain.Manga) error {
 }
 
 // GetImageURLs gets all image urls for a chapter
-func (w *weebcentral) GetImageURLs(_ context.Context, chapter *domain.Chapter) error {
-	var imageURLs []string
-
-	page := stealth.MustPage(w.Browser.Get())
-	defer page.MustClose()
-
-	pageWithTimeout := page.Timeout(browser.Timeout)
-
-	if err := pageWithTimeout.Navigate(chapter.URL); err != nil {
-		return fmt.Errorf("navigating to image page: %w", browser.HandleError(err))
-	}
-
-	if err := pageWithTimeout.WaitLoad(); err != nil {
-		return fmt.Errorf("waiting for image page load: %w", browser.HandleError(err))
-	}
-
-	if err := pageWithTimeout.WaitElementsMoreThan("img.maw-w-full", 0); err != nil {
-		return fmt.Errorf("waiting for chapter images: %w", browser.HandleError(err))
-	}
-
-	raw, err := pageWithTimeout.Eval(`() => {
-		return Array.from(document.querySelectorAll("img.maw-w-full"))
-			.map((img) => img.getAttribute("src") ?? "")
-			.filter((src) => src !== "")
-	}`)
+func (w *weebcentral) GetImageURLs(ctx context.Context, chapter *domain.Chapter) error {
+	imageURL, err := w.chapterImagesURL(chapter.URL)
 	if err != nil {
-		return fmt.Errorf("extracting chapter image URLs: %w", browser.HandleError(err))
+		return fmt.Errorf("building chapter images URL from %s: %w", chapter.URL, err)
 	}
 
-	if err := raw.Value.Unmarshal(&imageURLs); err != nil {
-		return fmt.Errorf("decoding chapter image URLs: %w", err)
+	body, err := w.fetch(ctx, imageURL)
+	if err != nil {
+		return fmt.Errorf("fetching chapter images %s: %w", imageURL, err)
+	}
+
+	imageURLs, err := w.extractImageURLs(body)
+	if err != nil {
+		return fmt.Errorf("extracting chapter image URLs from %s: %w", imageURL, err)
 	}
 
 	if len(imageURLs) == 0 {
@@ -183,6 +175,90 @@ func (w *weebcentral) GetImageURLs(_ context.Context, chapter *domain.Chapter) e
 
 	chapter.ImageInfo = imageInfos
 	return nil
+}
+
+func (w *weebcentral) chapterImagesURL(chapterURL string) (string, error) {
+	parsed, err := url.Parse(chapterURL)
+	if err != nil {
+		return "", err
+	}
+
+	parsed.RawQuery = ""
+	parsed.Fragment = ""
+
+	imageURL, err := url.JoinPath(parsed.String(), "images")
+	if err != nil {
+		return "", err
+	}
+
+	u, err := url.Parse(imageURL)
+	if err != nil {
+		return "", err
+	}
+
+	params := u.Query()
+	params.Set("is_prev", "False")
+	params.Set("current_page", "1")
+	params.Set("reading_style", "long_strip")
+	u.RawQuery = params.Encode()
+
+	return u.String(), nil
+}
+
+func (w *weebcentral) fetch(ctx context.Context, rawURL string) ([]byte, error) {
+	var body []byte
+
+	err := retry.Do(func() error {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+		if err != nil {
+			return fmt.Errorf("creating request for %s: %w", rawURL, err)
+		}
+
+		req.Header.Set("User-Agent", "Mozilla/5.0 (compatible; mangarr/1.0; +https://github.com/nuxencs/mangarr)")
+		req.Header.Set("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")
+
+		resp, err := sharedhttp.ExecRequest(w.Client, req)
+		if err != nil {
+			return err
+		}
+		defer resp.Body.Close()
+
+		body, err = io.ReadAll(resp.Body)
+		if err != nil {
+			return fmt.Errorf("reading response body from %s: %w", rawURL, err)
+		}
+
+		return nil
+	}, sharedhttp.RetryOptions(ctx)...)
+	if err != nil {
+		return nil, err
+	}
+
+	return body, nil
+}
+
+func (w *weebcentral) extractImageURLs(body []byte) ([]string, error) {
+	doc, err := goquery.NewDocumentFromReader(bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+
+	imageURLs := make([]string, 0)
+	doc.Find("img[src]").Each(func(_ int, selection *goquery.Selection) {
+		src := strings.TrimSpace(selection.AttrOr("src", ""))
+		if len(src) == 0 {
+			return
+		}
+
+		resolvedURL, err := resolveAgainstBase(w.BaseURL, src)
+		if err != nil {
+			return
+		}
+
+		imageURLs = append(imageURLs, resolvedURL)
+	})
+
+	return dedupeStrings(imageURLs), nil
 }
 
 // getChapterNumber gets the chapter number from the scraped chapter name

--- a/internal/source/weebcentral_test.go
+++ b/internal/source/weebcentral_test.go
@@ -1,0 +1,97 @@
+package source
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"mangarr/internal/domain"
+
+	"github.com/gocolly/colly"
+	"github.com/gocolly/colly/extensions"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWeebCentralGetImageURLsExtractsChapterAssets(t *testing.T) {
+	t.Parallel()
+
+	const chapterPath = "/chapters/01TESTCHAPTER"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case chapterPath + "/images":
+			require.Equal(t, "False", r.URL.Query().Get("is_prev"))
+			require.Equal(t, "1", r.URL.Query().Get("current_page"))
+			require.Equal(t, "long_strip", r.URL.Query().Get("reading_style"))
+
+			fmt.Fprint(w, `
+				<section>
+					<img src="https://cdn.weebcentral.test/manga/chapter-001.png" />
+					<img src="/media/chapter-002.png" />
+					<img src="https://cdn.weebcentral.test/manga/chapter-001.png" />
+				</section>
+			`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	src := newTestWeebCentral(server.URL+"/series/series-id", server.URL)
+
+	chapter := domain.Chapter{
+		URL:    server.URL + chapterPath + "?foo=bar#reader",
+		Number: domain.MustParseChapterNumber("340.2"),
+	}
+
+	err := src.GetImageURLs(t.Context(), &chapter)
+	require.NoError(t, err)
+	require.Len(t, chapter.ImageInfo, 2)
+	require.Equal(t, "https://cdn.weebcentral.test/manga/chapter-001.png", chapter.ImageInfo[0].ImageURL)
+	require.Equal(t, server.URL+"/media/chapter-002.png", chapter.ImageInfo[1].ImageURL)
+}
+
+func TestWeebCentralGetImageURLsErrorsWhenFragmentHasNoImages(t *testing.T) {
+	t.Parallel()
+
+	const chapterPath = "/chapters/01EMPTYCHAPTER"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case chapterPath + "/images":
+			fmt.Fprint(w, `<section><p>No pages.</p></section>`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	src := newTestWeebCentral(server.URL+"/series/series-id", server.URL)
+
+	chapter := domain.Chapter{
+		URL:    server.URL + chapterPath,
+		Number: domain.MustParseChapterNumber("1"),
+	}
+
+	err := src.GetImageURLs(t.Context(), &chapter)
+	require.EqualError(t, err, "getting image URLs for chapter 1")
+}
+
+func newTestWeebCentral(mangaURL, baseURL string) *weebcentral {
+	collector := colly.NewCollector(
+		colly.AllowURLRevisit(),
+	)
+	extensions.RandomUserAgent(collector)
+	collector.SetRequestTimeout(10 * time.Second)
+
+	return &weebcentral{
+		MangaURL:  mangaURL,
+		Collector: *collector,
+		BaseURL:   baseURL,
+		Client: http.Client{
+			Timeout: 10 * time.Second,
+		},
+	}
+}


### PR DESCRIPTION
## Summary
- replace Weeb Central browser-based chapter image extraction with direct HTTP fetches to the current `/chapters/<id>/images` fragment endpoint
- remove now-dead browser manager plumbing from Weeb Central constructor/call sites
- add regression tests and update adapter/docs references

## Verification
- gofix/gofumpt on touched Go files
- `go test ./...`
- `go test -race ./...`
- `go build ./...`
- `go run . download -d /tmp/mangarr-weebcentral-smoke-2 -s weebcentral -m https://weebcentral.com/series/01J76XYD7E91K8QP6CY0Y53900 -L`

## Notes
- `govulncheck ./...` still reports existing unrelated `GO-2026-4526` in `github.com/antchfx/xpath` via `flamecomics`/`colly`.