### PR TITLE
chore: remove chromium from docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,9 +325,9 @@ docker-compose up -d
 - **Manga URL**: Gist URL for the manga
 - **Group**: Group identifier (e.g., `/r/OnePunchMan`)
 
-### Browser-Based Sources (Weeb Central)
+### Runtime Dependencies
 
-Some sources use browser automation to bypass Cloudflare protection. These may take slightly longer to process.
+Current sources use direct HTTP/HTML extraction. The published Docker image does not require Chromium.
 
 ## How It Works
 

--- a/ci.Dockerfile
+++ b/ci.Dockerfile
@@ -30,7 +30,7 @@ RUN --network=none --mount=target=. \
 
 # build runner
 FROM alpine:latest AS runner
-RUN apk add --no-cache ca-certificates curl tzdata jq chromium tini
+RUN apk add --no-cache ca-certificates curl tzdata jq tini
 
 LABEL org.opencontainers.image.source="https://github.com/nuxencs/mangarr" \
     org.opencontainers.image.licenses="MIT" \

--- a/docs/RELIABILITY.md
+++ b/docs/RELIABILITY.md
@@ -1,12 +1,12 @@
 # RELIABILITY.md
 
-Verified on 2026-03-07.
+Verified on 2026-03-26.
 
 ## Main Failure Modes
 
 - upstream HTML/API changes break adapters
 - remote rate limits or transient outages
-- browser automation runtime issues
+- source-specific transport or anti-bot changes
 - invalid local config or download path
 - partial chapter download failures
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -1,29 +1,29 @@
 # SECURITY.md
 
-Verified on 2026-03-07.
+Verified on 2026-03-26.
 
 ## Trust Boundaries
 
 - untrusted remote HTML/API responses from manga sources
 - local filesystem writes for archives and optional logs
-- optional browser automation against third-party sites
+- outbound HTTP access to third-party manga sources
 - GitHub release and container publishing pipeline
 
 ## Current Posture
 
 - no multi-user server surface
 - no database or credential store in repo code
-- primary security risks come from third-party content, browser automation, and supply chain dependencies
+- primary security risks come from third-party content and supply chain dependencies
 
 ## Safe Defaults
 
 - validate source inputs before network work
 - keep archive output under explicit user-selected directories
-- prefer shared HTTP/browser code paths over ad hoc adapter-local clients
+- prefer shared HTTP code paths over ad hoc adapter-local clients
 - document new dependencies before adoption
 
 ## Gaps
 
 - no documented vuln-scanning routine beyond normal dependency hygiene
-- no sandboxing around browser-backed adapters
+- no dedicated egress allowlist or source isolation controls
 - no CI checks focused specifically on dependency or docs-governance risk

--- a/docs/product-specs/monitoring-operator.md
+++ b/docs/product-specs/monitoring-operator.md
@@ -1,6 +1,6 @@
 # Monitoring Operator
 
-Verified against `cmd/monitor.go` and `internal/config/config.go` on 2026-03-07.
+Verified against `cmd/monitor.go` and `internal/config/config.go` on 2026-03-26.
 
 ## User Goal
 
@@ -18,4 +18,4 @@ Run `mangarr monitor` unattended and trust it to fetch new chapters without cons
 - config behavior is documented and matches runtime
 - monitor logs remain actionable for source failures
 - failure handling does not corrupt already-downloaded archives
-- browser-backed source requirements are documented
+- source-specific runtime requirements stay documented when they appear

--- a/docs/product-specs/new-user-onboarding.md
+++ b/docs/product-specs/new-user-onboarding.md
@@ -1,6 +1,6 @@
 # New User Onboarding
 
-Verified against `README.md` on 2026-03-07.
+Verified against `README.md` on 2026-03-26.
 
 ## User Goal
 
@@ -18,7 +18,7 @@ Get one manga chapter downloaded quickly, with minimal setup and no code reading
 
 - source identifiers vary widely by provider
 - some sources need full URLs, some IDs, some titles
-- browser-backed sources add runtime dependency complexity
+- source-specific identifier requirements still add setup friction
 
 ## Acceptance Bar
 


### PR DESCRIPTION
## Summary
- remove the unused `chromium` package from the Docker runner image
- update README and operator docs to reflect that current sources use direct HTTP/HTML extraction
- keep packaging/runtime docs aligned with the current no-browser state

## Verification
- `go test ./...`
- `go test -race ./...`
- `go build ./...`
- `docker build -f ci.Dockerfile .`
