### PR TITLE
docs(readme): make root docs user-facing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,370 +1,107 @@
 # Mangarr
 
-**Mangarr** is a command-line tool and monitoring service for downloading manga chapters from various sources. It supports both one-time downloads and continuous monitoring for new chapter releases.
+**Mangarr** downloads manga chapters from supported sources and saves them as `.cbz` archives.
+Use it for quick one-off downloads or let it run in monitor mode and fetch new chapters for you.
 
 [![Release](https://img.shields.io/github/v/release/nuxencs/mangarr?display_name=tag&style=flat-square)](https://github.com/nuxencs/mangarr/releases/latest)
 [![License](https://img.shields.io/github/license/nuxencs/mangarr?style=flat-square)](https://github.com/nuxencs/mangarr/blob/main/LICENSE)
-[![Docker Pulls](https://img.shields.io/docker/pulls/ghcr.io/nuxencs/mangarr?style=flat-square)](https://ghcr.io/nuxencs/mangarr)
 
-## Features
+## Why Use It
 
-- 📥 **Download chapters** from multiple manga sources with a single command
-- 🔄 **Monitor manga** automatically and download new chapters as they're released
-- 📦 **CBZ archive format** - chapters are saved as `.cbz` files for easy reading with comic book readers
-- 🎨 **Customizable naming** - define your own chapter naming templates
-- 🌍 **Multi-language support** - download manga in different languages (source-dependent)
-- 📋 **Flexible chapter selection** - download first, latest, specific chapters, ranges, or all chapters
-- ⚙️ **Configuration** - use YAML config files or environment variables
-- 🐳 **Docker support** - run as a containerized service
+- Download the latest, first, specific, or all available chapters.
+- Monitor series and auto-download new releases.
+- Save chapters as `.cbz` files that work with comic and manga readers.
+- Run as a native binary or with Docker.
 
-## Supported Sources
+## Install
 
-Mangarr currently supports downloading from **8 different manga sources**:
-
-| Source | Identifier | Notes |
-|--------|-----------|-------|
-| [TCB Scans](https://tcbonepiecechapters.com/) | `tcbscans` | Requires manga title |
-| [MangaDex](https://mangadex.org/) | `mangadex` | Requires manga ID (UUID), supports group filtering and language selection |
-| [MANGA Plus](https://mangaplus.shueisha.co.jp/) | `mangaplus` | Requires manga ID (numeric) |
-| [Flame Comics](https://flamecomics.xyz/) | `flamecomics` | Requires full manga URL |
-| [Asura Scans](https://asurascans.com/) | `asurascans` | Requires a current `https://asurascans.com/comics/...` series URL; locked early-access chapters are skipped until public |
-| [Cubari](https://cubari.moe/) | `cubari` | Requires gist URL and group identifier |
-| [Weeb Central](https://weebcentral.com/) | `weebcentral` | Requires manga identifier, uses direct HTML image extraction |
-| [Comix](https://comix-online.org/) | `comix` | Requires manga identifier and group |
-
-## Installation
-
-### Download Binary
+### Binary
 
 Download the latest release for your platform from the [releases page](https://github.com/nuxencs/mangarr/releases/latest).
 
 Available for:
-- Linux (amd64, arm, arm64)
-- Windows (amd64)
-- macOS (amd64, arm64)
-- FreeBSD (amd64)
+
+- Linux (`amd64`, `arm`, `arm64`)
+- Windows (`amd64`)
+- macOS (`amd64`, `arm64`)
+- FreeBSD (`amd64`)
 
 ### Docker
-
-Pull the Docker image:
 
 ```bash
 docker pull ghcr.io/nuxencs/mangarr:latest
 ```
 
-Or use Docker Compose - see the [Docker Compose Setup](#docker-compose-setup) section.
-
-## Knowledge Base
-
-Maintainer docs use a progressive-disclosure layout:
-
-- [Architecture](./ARCHITECTURE.md) - top-level domain and package map
-- [Design Guide](./docs/DESIGN.md) - design-doc entry point and core beliefs
-- [Plans Guide](./docs/PLANS.md) - active/completed execution plans + tech debt
-- [Product Sense](./docs/PRODUCT_SENSE.md) - user priorities and tradeoffs
-- [Quality Score](./docs/QUALITY_SCORE.md) - current grades by domain/layer
-- [Reliability](./docs/RELIABILITY.md) - failure modes and verification
-- [Security](./docs/SECURITY.md) - trust boundaries and safe defaults
-
-## Usage
-
-### Quick Start - Download Command
-
-The `download` command allows you to download manga chapters on-demand:
-
-```bash
-mangarr download -d <download-directory> -s <source> -m <manga-identifier> [options]
-```
-
-**Required Flags:**
-- `-d, --downloadDirectory` - Directory where downloads will be saved
-- `-s, --source` - Source to download from (see [Supported Sources](#supported-sources))
-- `-m, --manga` - Manga identifier (varies by source: title, ID, or URL)
-
-**Optional Flags:**
-- `-n, --naming` - Naming template (default: `{manga:<.>} Ch. {num:3}{title: - <.>}`)
-- `-o, --overwrite` - Override the manga title
-- `-g, --group` - Scanlation group (for sources that support it)
-- `-l, --language` - Language code (default: `en`, for sources that support it)
-
-**Chapter Selection (mutually exclusive):**
-- `-1, --first` - Download the first chapter
-- `-L, --latest` - Download the latest chapter (default if no selection is specified)
-- `-C, --chapters` - Download specific chapters (e.g., `1,3,5` or `1-10`)
-- `-A, --all` - Download all available chapters
-
-### Examples
-
-**Download the latest chapter from TCB Scans:**
-```bash
-mangarr download -d ./downloads -s tcbscans -m "One Piece"
-```
-
-**Download the first chapter from MangaDex with specific group:**
-```bash
-mangarr download -d ./downloads -s mangadex -m "801513ba-a712-498c-8f57-cae55b38cc92" -g "277df5c9-a486-40f6-8dfa-c086c6b60935" -l en -1
-```
-
-**Download specific chapters from MANGA Plus:**
-```bash
-mangarr download -d ./downloads -s mangaplus -m "100037" -C "6,17"
-```
-
-**Download chapter range from Cubari:**
-```bash
-mangarr download -d ./downloads -s cubari -m "https://git.io/OPM" -g "/r/OnePunchMan" -C "1-3"
-```
-
-**Download all chapters from Flame Comics:**
-```bash
-mangarr download -d ./downloads -s flamecomics -m "https://flamecomics.xyz/series/solo-leveling-ragnarok/" -A
-```
-
-**Start monitoring all the manga in your config:**
-```bash
-mangarr monitor -c ./config/mangarr
-```
-
-### Monitor Command
-
-The `monitor` command runs continuously and checks for new chapters at regular intervals:
-
-```bash
-mangarr monitor -c <config-path>
-```
-
-**Flags:**
-- `-c, --config` - Path to configuration directory (optional)
-
-If no config path is specified, mangarr will search for `config.yaml` in:
-1. Current directory
-2. `~/.config/mangarr/`
-3. `~/.mangarr/`
-
-### Version Command
-
-Check the installed version and check for updates:
+Check the installed version:
 
 ```bash
 mangarr version
 ```
 
-## Configuration
+## Quick Start
 
-### Configuration File
+Download the latest chapter from a source:
 
-Create a `config.yaml` file to configure the monitor mode:
+```bash
+mangarr download --help
+mangarr download -d ./downloads -s tcbscans -m "One Piece"
+```
+
+If you want a different source, the value you pass to `-m` changes by provider. Use the table below.
+
+## Monitor Mode
+
+Create a `config.yaml`:
 
 ```yaml
-# Download Location (required)
 downloadLocation: "/path/to/downloads"
-
-# Naming Template
-# Available variables: {manga:<.>}, {num:3}, {title: - <.>}
-# Default: "{manga:<.>} Ch. {num:3}{title: - <.>}"
-namingTemplate: "{manga:<.>} Ch. {num:3}{title: - <.>}"
-
-# Check interval in minutes
-# Default: 15
 checkInterval: 15
 
-# Enable pprof endpoint for runtime profiling
-# Default: false
-pprofEnabled: false
-
-# pprof endpoint address
-# Default: "127.0.0.1:6060"
-pprofAddress: "127.0.0.1:6060"
-
-# Monitored Manga
 monitoredManga:
-  # Entry for TCB Scans
   One Piece:
     source: "tcbscans"
     manga: "One Piece"
-
-  # Entry for MangaDex with group and language
-  Isekai Ojisan:
-    source: "mangadex"
-    manga: "d8f1d7da-8bb1-407b-8be3-10ac2894d3c6"
-    group: "310361d7-52dd-4848-9b36-2eb4fcc95e83"
-    language: "en"
-    overwrite: "Uncle from Another World"
-
-  # Entry for MANGA Plus
-  Kagurabachi:
-    source: "mangaplus"
-    manga: "100274"
-
-  # Entry for Flame Comics
-  Solo Leveling Ragnarok:
-    source: "flamecomics"
-    manga: "https://flamecomics.xyz/series/solo-leveling-ragnarok/"
-
-  # Entry for Cubari
-  One Punch Man:
-    source: "cubari"
-    manga: "https://git.io/OPM"
-    group: "/r/OnePunchMan"
-
-# Logging configuration (optional)
-#logPath: "/path/to/logs/mangarr.log"
-logLevel: "DEBUG"  # Options: ERROR, DEBUG, INFO, WARN, TRACE
-#logMaxSize: 50     # Max log size in megabytes
-#logMaxBackups: 3   # Max number of old log files
 ```
 
-### Configuration Locations
-
-Mangarr will search for the configuration file in the following order:
-
-1. Path specified with `-c` or `--config` flag
-2. `config.yaml` in the default user configuration directory (`~/.config/mangarr/`)
-3. `config.yaml` in a folder inside your home directory (`~/.mangarr/`)
-4. `config.yaml` in the directory of the binary
-
-### Environment Variables
-
-You can override configuration values using environment variables with the `MANGARR__` prefix:
-
-- `MANGARR__DOWNLOAD_LOCATION` - Download directory path
-- `MANGARR__NAMING_TEMPLATE` - Naming template string
-- `MANGARR__CHECK_INTERVAL` - Check interval in minutes
-- `MANGARR__PPROF_ENABLED` - Enable/disable pprof endpoint (`true`/`false`)
-- `MANGARR__PPROF_ADDRESS` - pprof bind address (e.g. `127.0.0.1:6060`)
-- `MANGARR__LOG_LEVEL` - Log level (ERROR, DEBUG, INFO, WARN, TRACE)
-- `MANGARR__LOG_PATH` - Path to log file
-- `MANGARR__LOG_MAX_SIZE` - Maximum log file size in megabytes
-- `MANGARR__LOG_MAX_BACKUPS` - Maximum number of old log files to keep
-
-### Performance Profiling (pprof)
-
-Enable `pprofEnabled: true` in your monitor config, then start:
+Run the monitor:
 
 ```bash
-mangarr monitor -c ./config/mangarr
+mangarr monitor -c ~/.config/mangarr
 ```
 
-Check endpoint:
+`-c` should point to the directory that contains `config.yaml`.
+If you omit it, mangarr also checks common default locations. Full config and override details live in [docs/USAGE.md](./docs/USAGE.md).
 
-```bash
-curl http://127.0.0.1:6060/debug/pprof/
-```
+## Supported Sources
 
-Capture a CPU profile:
+| Source | `-s` value | Pass to `-m` | Extra input |
+| --- | --- | --- | --- |
+| [TCB Scans](https://tcbonepiecechapters.com/) | `tcbscans` | exact manga title | none |
+| [MangaDex](https://mangadex.org/) | `mangadex` | manga UUID | optional `-g` group UUID, optional `-l` language |
+| [MANGA Plus](https://mangaplus.shueisha.co.jp/) | `mangaplus` | numeric title ID | none |
+| [Flame Comics](https://flamecomics.xyz/) | `flamecomics` | full series URL | none |
+| [Asura Scans](https://asurascans.com/) | `asurascans` | full `https://asurascans.com/comics/...` URL | locked early-access chapters are skipped until public |
+| [Cubari](https://cubari.moe/) | `cubari` | gist URL | required `-g` group |
+| [Weeb Central](https://weebcentral.com/) | `weebcentral` | full `https://weebcentral.com/...` URL | none |
+| [Comix](https://comix.to/) | `comix` | full `https://comix.to/title/...` URL | optional `-g` group |
 
-```bash
-go tool pprof http://127.0.0.1:6060/debug/pprof/profile?seconds=30
-```
+## More Docs
 
-### Naming Templates
+User docs:
 
-Customize how chapters are named using template variables:
+- [Usage and config reference](./docs/USAGE.md)
+- [Security notes](./docs/SECURITY.md)
 
-| Variable | Description | Example |
-|----------|-------------|---------|
-| `{manga:<.>}` | Manga title | `One Piece` |
-| `{num:3}` | Chapter number (padded to 3 digits) | `001`, `010`, `100` |
-| `{num}` | Chapter number (no padding) | `1`, `10`, `100` |
-| `{title: - <.>}` | Chapter title with prefix | ` - Chapter Title` |
+Maintainer docs:
 
-**Example naming templates:**
-
-- Default: `{manga:<.>} Ch. {num:3}{title: - <.>}` → `One Piece Ch. 001 - Romance Dawn`
-- Simple: `{manga:<.>} - {num:3}` → `One Piece - 001`
-- With chapter word: `{manga:<.>} Chapter {num}` → `One Piece Chapter 1`
-
-## Docker Compose Setup
-
-Create a `docker-compose.yml` file:
-
-```yaml
-services:
-  mangarr:
-    container_name: mangarr
-    image: ghcr.io/nuxencs/mangarr:latest
-    restart: unless-stopped
-    user: ${PUID}:${PGID}  # Optional: Set user/group ID
-    environment:
-      - MANGARR__DOWNLOAD_LOCATION=/downloads
-      - MANGARR__CHECK_INTERVAL=15
-      - MANGARR__LOG_LEVEL=INFO
-    volumes:
-      - ./config:/config           # Configuration directory
-      - ./downloads:/downloads     # Download directory
-```
-
-Start the service:
-
-```bash
-docker-compose up -d
-```
-
-## Source-Specific Notes
-
-### MangaDex
-
-- **Manga ID**: Use the UUID from the manga URL (e.g., `https://mangadex.org/title/UUID`)
-- **Group ID**: Optional UUID of the scanlation group
-- **Language**: ISO 639-1 language code (default: `en`)
-
-### MANGA Plus
-
-- **Manga ID**: Numeric ID from the manga URL
-
-### TCB Scans
-
-- **Manga Title**: Exact manga title as it appears on the site
-
-### Flame Comics
-
-- **Manga URL**: Full URL to the manga page
-
-### Cubari
-
-- **Manga URL**: Gist URL for the manga
-- **Group**: Group identifier (e.g., `/r/OnePunchMan`)
-
-### Runtime Dependencies
-
-Current sources use direct HTTP/HTML extraction. The published Docker image does not require Chromium.
-
-## How It Works
-
-1. **Monitor Mode**: Mangarr checks configured manga sources at regular intervals
-2. **Chapter Detection**: Identifies the latest chapter number for each manga
-3. **Download Check**: Verifies if the chapter already exists locally
-4. **Download**: If new, downloads all chapter images and creates a CBZ archive
-5. **File Naming**: Uses the configured naming template to name the file
-
-Downloaded chapters are organized as:
-```
-downloads/
-└── Manga Title/
-    ├── Manga Title Ch. 001.cbz
-    ├── Manga Title Ch. 002.cbz
-    └── Manga Title Ch. 003.cbz
-```
-
-## Building from Source
-
-Requirements:
-- Go 1.24.2 or later
-
-```bash
-git clone https://github.com/nuxencs/mangarr.git
-cd mangarr
-go build -o mangarr
-```
-
-## Contributing
-
-Contributions are welcome! Please feel free to submit issues or pull requests.
+- [Architecture](./ARCHITECTURE.md)
+- [Design guide](./docs/DESIGN.md)
+- [Plans guide](./docs/PLANS.md)
 
 ## License
 
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+This project is licensed under the MIT License. See [LICENSE](./LICENSE).
 
 ## Disclaimer
 
-This tool is for personal use only. Please respect the rights of content creators and publishers. Support official releases when possible.
+Personal use only. Respect the rights of creators and publishers, and support official releases when possible.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1,0 +1,218 @@
+# Usage Reference
+
+Verified against CLI help and config/runtime code on 2026-03-27.
+
+Use this doc when the root README is not enough and you need command, config, or operator detail.
+
+## Commands
+
+### `download`
+
+Download one chapter, many chapters, or everything available from a supported source.
+
+```bash
+mangarr download -d <download-dir> -s <source> -m <identifier> [flags]
+```
+
+Common flags:
+
+| Flag | Meaning |
+| --- | --- |
+| `-d`, `--downloadDirectory` | directory where `.cbz` files are written |
+| `-s`, `--source` | source identifier such as `tcbscans` or `mangadex` |
+| `-m`, `--manga` | source-specific manga identifier |
+| `-g`, `--group` | group identifier for sources that support it |
+| `-l`, `--language` | language code for sources that support it; default `en` |
+| `-n`, `--naming` | filename template |
+| `-o`, `--overwrite` | replace the parsed manga title in the output filename |
+
+Chapter selection flags are mutually exclusive:
+
+- `-L`, `--latest`: latest chapter; default when no selector is set
+- `-1`, `--first`: first chapter
+- `-C`, `--chapters`: specific chapters or ranges such as `1,3,5` or `1-10`
+- `-A`, `--all`: all available chapters
+
+Examples:
+
+```bash
+# Latest chapter from TCB Scans
+mangarr download -d ./downloads -s tcbscans -m "One Piece"
+
+# First English chapter from MangaDex for one group
+mangarr download -d ./downloads -s mangadex -m "801513ba-a712-498c-8f57-cae55b38cc92" -g "277df5c9-a486-40f6-8dfa-c086c6b60935" -l en -1
+
+# Specific chapters from MANGA Plus
+mangarr download -d ./downloads -s mangaplus -m "100037" -C "6,17"
+
+# Chapter range from Cubari
+mangarr download -d ./downloads -s cubari -m "https://git.io/OPM" -g "/r/OnePunchMan" -C "1-3"
+
+# Latest chapter from Asura Scans
+mangarr download -d ./downloads -s asurascans -m "https://asurascans.com/comics/solo-max-level-newbie-7f873ca6" -L
+```
+
+### `monitor`
+
+Run mangarr as a long-lived watcher that checks configured series on an interval.
+
+```bash
+mangarr monitor -c <config-dir>
+```
+
+Minimal config:
+
+```yaml
+downloadLocation: "/path/to/downloads"
+checkInterval: 15
+
+monitoredManga:
+  One Piece:
+    source: "tcbscans"
+    manga: "One Piece"
+```
+
+Expanded config:
+
+```yaml
+downloadLocation: "/path/to/downloads"
+namingTemplate: "{manga:<.>} Ch. {num:3}{title: - <.>}"
+checkInterval: 15
+pprofEnabled: false
+pprofAddress: "127.0.0.1:6060"
+
+monitoredManga:
+  One Piece:
+    source: "tcbscans"
+    manga: "One Piece"
+
+  Isekai Ojisan:
+    source: "mangadex"
+    manga: "d8f1d7da-8bb1-407b-8be3-10ac2894d3c6"
+    group: "310361d7-52dd-4848-9b36-2eb4fcc95e83"
+    language: "en"
+    overwrite: "Uncle from Another World"
+
+  Kagurabachi:
+    source: "mangaplus"
+    manga: "100274"
+
+logLevel: "DEBUG"
+#logPath: "/path/to/logs/mangarr.log"
+#logMaxSize: 50
+#logMaxBackups: 3
+```
+
+Config lookup order:
+
+1. If `-c` is set, mangarr reads `<config-dir>/config.yaml`.
+2. `~/.config/mangarr/config.yaml`
+3. `~/.mangarr/config.yaml`
+4. `config.yaml` next to the binary
+
+Environment overrides use the `MANGARR__` prefix:
+
+- `MANGARR__DOWNLOAD_LOCATION`
+- `MANGARR__NAMING_TEMPLATE`
+- `MANGARR__CHECK_INTERVAL`
+- `MANGARR__PPROF_ENABLED`
+- `MANGARR__PPROF_ADDRESS`
+- `MANGARR__LOG_LEVEL`
+- `MANGARR__LOG_PATH`
+- `MANGARR__LOG_MAX_SIZE`
+- `MANGARR__LOG_MAX_BACKUPS`
+
+### `version`
+
+Show local build/version info.
+
+```bash
+mangarr version
+```
+
+## Source Inputs
+
+| Source | `-s` value | Pass to `-m` | Extra input |
+| --- | --- | --- | --- |
+| [TCB Scans](https://tcbonepiecechapters.com/) | `tcbscans` | exact manga title | none |
+| [MangaDex](https://mangadex.org/) | `mangadex` | manga UUID from the title URL | optional `-g` group UUID, optional `-l` language |
+| [MANGA Plus](https://mangaplus.shueisha.co.jp/) | `mangaplus` | numeric title ID | none |
+| [Flame Comics](https://flamecomics.xyz/) | `flamecomics` | full series URL | none |
+| [Asura Scans](https://asurascans.com/) | `asurascans` | current `https://asurascans.com/comics/...` series URL | locked early-access chapters are skipped until public |
+| [Cubari](https://cubari.moe/) | `cubari` | gist URL | required `-g` group such as `/r/OnePunchMan` |
+| [Weeb Central](https://weebcentral.com/) | `weebcentral` | full series URL | none |
+| [Comix](https://comix.to/) | `comix` | full `https://comix.to/title/...` URL | optional `-g` group; default is official releases |
+
+For implementation-level source behavior and validation rules, see [design-docs/source-adapters.md](./design-docs/source-adapters.md).
+
+## Naming Templates
+
+Available variables:
+
+| Variable | Meaning | Example |
+| --- | --- | --- |
+| `{manga:<.>}` | manga title | `One Piece` |
+| `{num:3}` | chapter number, padded to 3 digits | `001` |
+| `{num}` | chapter number, unpadded | `1` |
+| `{title: - <.>}` | chapter title with a prefix only when a title exists | ` - Romance Dawn` |
+
+Examples:
+
+- `{manga:<.>} Ch. {num:3}{title: - <.>}` -> `One Piece Ch. 001 - Romance Dawn`
+- `{manga:<.>} - {num:3}` -> `One Piece - 001`
+- `{manga:<.>} Chapter {num}` -> `One Piece Chapter 1`
+
+## Docker Compose
+
+Current sources use direct HTTP and HTML extraction. The published image does not require Chromium.
+
+```yaml
+services:
+  mangarr:
+    container_name: mangarr
+    image: ghcr.io/nuxencs/mangarr:latest
+    restart: unless-stopped
+    user: ${PUID}:${PGID}
+    environment:
+      - MANGARR__DOWNLOAD_LOCATION=/downloads
+      - MANGARR__CHECK_INTERVAL=15
+      - MANGARR__LOG_LEVEL=INFO
+    volumes:
+      - ./config:/config
+      - ./downloads:/downloads
+```
+
+Start it:
+
+```bash
+docker compose up -d
+```
+
+## Advanced Ops
+
+Enable profiling:
+
+```yaml
+pprofEnabled: true
+pprofAddress: "127.0.0.1:6060"
+```
+
+Then:
+
+```bash
+mangarr monitor -c ./config
+curl http://127.0.0.1:6060/debug/pprof/
+go tool pprof http://127.0.0.1:6060/debug/pprof/profile?seconds=30
+```
+
+## Build From Source
+
+Requirements:
+
+- Go 1.24.2 or later
+
+```bash
+git clone https://github.com/nuxencs/mangarr.git
+cd mangarr
+go build -o mangarr
+```

--- a/docs/exec-plans/completed/2026-03-27-user-facing-readme-rewrite.md
+++ b/docs/exec-plans/completed/2026-03-27-user-facing-readme-rewrite.md
@@ -1,0 +1,47 @@
+# User-Facing README Rewrite
+
+Status: completed on 2026-03-27.
+
+## Problem
+
+The root README had drifted into a mixed user-plus-maintainer document. First-run guidance, config reference, runtime internals, and maintainer knowledge-base links all competed for attention.
+
+## Scope
+
+- rewrite the root README as a user-first landing page
+- move deeper command/config/operator detail into a docs page
+- keep maintainer and architecture detail in the existing internal docs
+- update onboarding docs to match the new entrypoint flow
+
+## Non-Goals
+
+- CLI behavior changes
+- config schema changes
+- command help text cleanup
+
+## Decisions
+
+- keep the root README focused on install, quick start, monitor setup, and supported-source inputs
+- add `docs/USAGE.md` as the deeper user/operator reference
+- keep source identifier expectations in the README because they block first success
+- keep maintainer links available, but secondary
+
+## Progress Log
+
+- reviewed the current README, architecture docs, and product onboarding docs
+- verified command help and actual config lookup behavior against the code
+- rewrote the README around user tasks instead of implementation detail
+- added a dedicated usage/config reference doc for material removed from the root README
+- updated the onboarding spec to reflect the new doc split
+
+## Verification
+
+- `go run . --help`
+- `go run . download --help`
+- `go run . monitor --help`
+- manual review of README/doc links
+- manual review of config-path wording against `internal/config/config.go`
+
+## Follow-Up
+
+- consider fixing CLI help text that says `--config` is a config file path; current runtime uses a config directory when the flag is set

--- a/docs/product-specs/new-user-onboarding.md
+++ b/docs/product-specs/new-user-onboarding.md
@@ -1,6 +1,6 @@
 # New User Onboarding
 
-Verified against `README.md` on 2026-03-26.
+Verified against `README.md` and `docs/USAGE.md` on 2026-03-27.
 
 ## User Goal
 
@@ -11,7 +11,7 @@ Get one manga chapter downloaded quickly, with minimal setup and no code reading
 1. install binary or pull Docker image
 2. run `mangarr download --help`
 3. choose a supported source
-4. supply source-specific manga identifier
+4. supply the source-specific manga identifier
 5. save latest chapter to a local directory
 
 ## Friction Points
@@ -19,9 +19,11 @@ Get one manga chapter downloaded quickly, with minimal setup and no code reading
 - source identifiers vary widely by provider
 - some sources need full URLs, some IDs, some titles
 - source-specific identifier requirements still add setup friction
+- users need a clear path from quick start to deeper config/reference docs
 
 ## Acceptance Bar
 
-- README quick-start examples stay accurate
+- root README stays short and user-facing
+- quick-start examples stay accurate
 - source input expectations are easy to find
-- first successful `download` does not require reading Go code
+- deeper config and operator detail is reachable from README without reading Go code


### PR DESCRIPTION
## Summary
- rewrite the root README as a user-facing landing page
- move deeper command/config/operator detail into docs/USAGE.md
- update onboarding docs and add a completed execution note

## Verification
- go run . --help
- go run . download --help
- go run . monitor --help
- go test ./...
- go test -race ./...
- go build ./...