### PR TITLE
feat(source): add atsumaru provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ If you omit it, mangarr also checks common default locations. Full config and ov
 | [Cubari](https://cubari.moe/) | `cubari` | gist URL | required `-g` group |
 | [Weeb Central](https://weebcentral.com/) | `weebcentral` | full `https://weebcentral.com/...` URL | none |
 | [Comix](https://comix.to/) | `comix` | full `https://comix.to/title/...` URL | optional `-g` group |
+| [Atsumaru](https://atsu.moe/) | `atsumaru` | full `https://atsu.moe/manga/...` URL | required `-g` scan ID |
 
 ## More Docs
 

--- a/cmd/download.go
+++ b/cmd/download.go
@@ -58,6 +58,8 @@ var downloadCmd = &cobra.Command{
 			s = source.NewWeebCentral(manga)
 		case "comix":
 			s = source.NewComix(manga, group)
+		case "atsumaru":
+			s = source.NewAtsumaru(manga, group)
 		default:
 			log.Error().Msgf("Invalid source: %s", mangaSource)
 			return

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1,6 +1,6 @@
 # Usage Reference
 
-Verified against CLI help and config/runtime code on 2026-03-27.
+Verified against CLI help and config/runtime code on 2026-05-19.
 
 Use this doc when the root README is not enough and you need command, config, or operator detail.
 
@@ -50,6 +50,9 @@ mangarr download -d ./downloads -s cubari -m "https://git.io/OPM" -g "/r/OnePunc
 
 # Latest chapter from Asura Scans
 mangarr download -d ./downloads -s asurascans -m "https://asurascans.com/comics/solo-max-level-newbie-7f873ca6" -L
+
+# Latest chapter from Atsumaru
+mangarr download -d ./downloads -s atsumaru -m "https://atsu.moe/manga/Q5Mqy" -g "cmgzlsevifjhtm191rqugvee3" -L
 ```
 
 ### `monitor`
@@ -142,6 +145,7 @@ mangarr version
 | [Cubari](https://cubari.moe/) | `cubari` | gist URL | required `-g` group such as `/r/OnePunchMan` |
 | [Weeb Central](https://weebcentral.com/) | `weebcentral` | full series URL | none |
 | [Comix](https://comix.to/) | `comix` | full `https://comix.to/title/...` URL | optional `-g` group; default is official releases |
+| [Atsumaru](https://atsu.moe/) | `atsumaru` | full `https://atsu.moe/manga/...` URL | required `-g` scan ID |
 
 For implementation-level source behavior and validation rules, see [design-docs/source-adapters.md](./design-docs/source-adapters.md).
 

--- a/docs/design-docs/source-adapters.md
+++ b/docs/design-docs/source-adapters.md
@@ -1,6 +1,6 @@
 # Source Adapters
 
-Verified against `internal/source/` on 2026-03-26.
+Verified against `internal/source/` on 2026-05-19.
 
 All adapters implement `domain.Source`.
 
@@ -16,6 +16,7 @@ All adapters implement `domain.Source`.
 | `cubari` | gist URL | `-g` required | valid URL + non-empty group | images resolved in payload |
 | `weebcentral` | full series URL | none | `https://weebcentral.com` prefix | scraper + chapter image fragment fetch |
 | `comix` | full title URL | `-g` optional | `https://comix.to/title` prefix | API-based |
+| `atsumaru` | full manga URL | `-g` required | `https://atsu.moe/manga/...` prefix + non-empty scan ID | API-based |
 
 ## Rules
 
@@ -30,5 +31,6 @@ All adapters implement `domain.Source`.
 - unknown source values fail fast in source selection
 - `asurascans` removes chapters marked `is_locked=true` before returning the chapter map
 - `weebcentral` fetches chapter images from the `/chapters/<id>/images` HTML fragment
+- `atsumaru` fetches chapter metadata from `/api/manga/info`, filters chapters by scan ID, and resolves relative page paths from `/api/read/chapter`
 - retry policy comes from `internal/sharedhttp/`
 - manhwa/long-strip handling flows through `selectedManga.IsManhwa`

--- a/docs/exec-plans/completed/2026-05-19-atsumaru-provider.md
+++ b/docs/exec-plans/completed/2026-05-19-atsumaru-provider.md
@@ -1,0 +1,34 @@
+# Atsumaru Provider
+
+## Problem
+
+Add `atsu.moe` as a source provider so users can download chapters from a manga URL such as `https://atsu.moe/manga/Q5Mqy`.
+
+## Scope
+
+- Added source key `atsumaru`.
+- Accepted full Atsu manga URLs through `-m` and required scan IDs through `-g`.
+- Used Atsu JSON APIs for manga info and chapter pages.
+- Preserved API chapter titles.
+- Updated docs and added adapter regression tests.
+
+## Decisions
+
+- Raw manga IDs are not accepted as public input.
+- `-g` maps to Atsu `scanId` and filters duplicate chapter numbers by scanlation upload.
+- `forceStrip` maps to `domain.Manga.IsManhwa`.
+- Page image paths are resolved against `https://atsu.moe`.
+- No new dependency was needed.
+
+## Verification
+
+- `go test ./internal/source`
+- `go test ./...`
+- `go test -race ./...`
+- `go build ./...`
+- `mkdir -p /tmp/mangarr-atsumaru-smoke`
+- `go run . download -d /tmp/mangarr-atsumaru-smoke -s atsumaru -m https://atsu.moe/manga/Q5Mqy -g cmgzlsevifjhtm191rqugvee3 -L`
+
+Live smoke produced:
+
+- `/tmp/mangarr-atsumaru-smoke/Kagurabachi/Kagurabachi Ch. 121 - Chapter 121.cbz`

--- a/internal/source/atsumaru.go
+++ b/internal/source/atsumaru.go
@@ -1,0 +1,259 @@
+package source
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"mangarr/internal/domain"
+	"mangarr/internal/sanitize"
+	"mangarr/internal/sharedhttp"
+
+	"github.com/avast/retry-go"
+)
+
+const atsumaruURL = "https://atsu.moe"
+
+type atsumaru struct {
+	MangaURL string
+	ScanID   string
+	Client   *http.Client
+	BaseURL  string
+}
+
+type atsumaruMangaResponse struct {
+	ID         string            `json:"id"`
+	Title      string            `json:"title"`
+	ForceStrip bool              `json:"forceStrip"`
+	Chapters   []atsumaruChapter `json:"chapters"`
+}
+
+type atsumaruChapter struct {
+	ID     string               `json:"id"`
+	Title  string               `json:"title"`
+	Number domain.ChapterNumber `json:"number"`
+	ScanID string               `json:"scanId"`
+}
+
+type atsumaruReadChapterResponse struct {
+	ReadChapter struct {
+		ID    string         `json:"id"`
+		Title string         `json:"title"`
+		Pages []atsumaruPage `json:"pages"`
+	} `json:"readChapter"`
+}
+
+type atsumaruPage struct {
+	Image string `json:"image"`
+}
+
+func NewAtsumaru(mangaURL, scanID string) domain.Source {
+	client := http.Client{
+		Timeout:   60 * time.Second,
+		Transport: sharedhttp.Transport,
+	}
+
+	return &atsumaru{
+		MangaURL: mangaURL,
+		ScanID:   scanID,
+		Client:   &client,
+		BaseURL:  atsumaruURL,
+	}
+}
+
+func (a *atsumaru) String() string {
+	return "Atsumaru"
+}
+
+func (a *atsumaru) ValidateInput() error {
+	if len(a.MangaURL) == 0 {
+		return fmt.Errorf("atsumaru manga URL is required")
+	}
+
+	if len(a.ScanID) == 0 {
+		return fmt.Errorf("atsumaru scan ID is required")
+	}
+
+	parsed, err := url.Parse(a.MangaURL)
+	if err != nil {
+		return fmt.Errorf("parsing URL %s: %w", a.MangaURL, err)
+	}
+
+	if parsed.Scheme != "https" || strings.ToLower(parsed.Host) != "atsu.moe" {
+		return fmt.Errorf("the URL for Atsumaru must start with %s", atsumaruURL)
+	}
+
+	if _, err := a.extractMangaID(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (a *atsumaru) GetManga(ctx context.Context) (domain.Manga, error) {
+	mangaID, err := a.extractMangaID()
+	if err != nil {
+		return domain.Manga{}, err
+	}
+
+	apiURL, err := a.apiURL("api/manga/info", url.Values{"mangaId": []string{mangaID}})
+	if err != nil {
+		return domain.Manga{}, err
+	}
+
+	var mangaResp atsumaruMangaResponse
+	if err := a.getJSON(ctx, apiURL, &mangaResp); err != nil {
+		return domain.Manga{}, fmt.Errorf("getting manga info from %s: %w", apiURL, err)
+	}
+
+	if len(mangaResp.Title) == 0 {
+		return domain.Manga{}, fmt.Errorf("getting manga for ID %s", mangaID)
+	}
+
+	manga := domain.Manga{
+		ID:       mangaResp.ID,
+		URL:      a.MangaURL,
+		Title:    sanitize.Filename(mangaResp.Title),
+		Chapters: make(map[domain.ChapterNumber]domain.Chapter),
+		IsManhwa: mangaResp.ForceStrip,
+	}
+	if manga.ID == "" {
+		manga.ID = mangaID
+	}
+
+	for _, chapter := range mangaResp.Chapters {
+		if chapter.ScanID != a.ScanID {
+			continue
+		}
+
+		manga.Chapters[chapter.Number] = domain.Chapter{
+			ID:     chapter.ID,
+			Number: chapter.Number,
+			Title:  sanitize.Filename(chapter.Title),
+		}
+	}
+
+	if len(manga.Chapters) == 0 {
+		return domain.Manga{}, fmt.Errorf("getting chapters for manga %s", manga.Title)
+	}
+
+	return manga, nil
+}
+
+func (a *atsumaru) GetChapters(_ context.Context, _ domain.Manga) error {
+	return nil
+}
+
+func (a *atsumaru) GetImageURLs(ctx context.Context, chapter *domain.Chapter) error {
+	mangaID, err := a.extractMangaID()
+	if err != nil {
+		return err
+	}
+
+	apiURL, err := a.apiURL("api/read/chapter", url.Values{
+		"mangaId":   []string{mangaID},
+		"chapterId": []string{chapter.ID},
+	})
+	if err != nil {
+		return err
+	}
+
+	var chapterResp atsumaruReadChapterResponse
+	if err := a.getJSON(ctx, apiURL, &chapterResp); err != nil {
+		return fmt.Errorf("getting chapter pages from %s: %w", apiURL, err)
+	}
+
+	imageInfos := make([]domain.ImageInfo, 0, len(chapterResp.ReadChapter.Pages))
+	for _, page := range chapterResp.ReadChapter.Pages {
+		imageURL, err := a.resolveImageURL(page.Image)
+		if err != nil {
+			return fmt.Errorf("resolving image URL %s: %w", page.Image, err)
+		}
+
+		imageInfos = append(imageInfos, domain.ImageInfo{ImageURL: imageURL})
+	}
+
+	if len(imageInfos) == 0 {
+		return fmt.Errorf("getting image URLs for chapter ID %s", chapter.ID)
+	}
+
+	chapter.ImageInfo = imageInfos
+	return nil
+}
+
+func (a *atsumaru) extractMangaID() (string, error) {
+	parsed, err := url.Parse(a.MangaURL)
+	if err != nil {
+		return "", fmt.Errorf("parsing URL %s: %w", a.MangaURL, err)
+	}
+
+	parts := strings.Split(strings.Trim(parsed.Path, "/"), "/")
+	if len(parts) != 2 || parts[0] != "manga" || parts[1] == "" {
+		return "", fmt.Errorf("invalid Atsumaru manga URL path")
+	}
+
+	return parts[1], nil
+}
+
+func (a *atsumaru) apiURL(path string, params url.Values) (string, error) {
+	u, err := url.JoinPath(a.BaseURL, path)
+	if err != nil {
+		return "", fmt.Errorf("building URL: %w", err)
+	}
+
+	parsed, err := url.Parse(u)
+	if err != nil {
+		return "", fmt.Errorf("parsing URL %s: %w", u, err)
+	}
+
+	parsed.RawQuery = params.Encode()
+	return parsed.String(), nil
+}
+
+func (a *atsumaru) getJSON(ctx context.Context, rawURL string, target any) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return fmt.Errorf("creating request: %w", err)
+	}
+
+	req.Header.Set("User-Agent", "mangarr")
+
+	retryErr := retry.Do(func() error {
+		resp, err := sharedhttp.ExecRequest(*a.Client, req)
+		if err != nil {
+			return err
+		}
+		defer resp.Body.Close()
+
+		if err := json.NewDecoder(resp.Body).Decode(target); err != nil {
+			return retry.Unrecoverable(fmt.Errorf("decoding response: %w", err))
+		}
+
+		return nil
+	},
+		sharedhttp.RetryOptions(ctx)...,
+	)
+	if retryErr != nil {
+		return fmt.Errorf("executing request %s: %w", req.URL, retryErr)
+	}
+
+	return nil
+}
+
+func (a *atsumaru) resolveImageURL(rawImageURL string) (string, error) {
+	base, err := url.Parse(a.BaseURL)
+	if err != nil {
+		return "", err
+	}
+
+	imageURL, err := url.Parse(rawImageURL)
+	if err != nil {
+		return "", err
+	}
+
+	return base.ResolveReference(imageURL).String(), nil
+}

--- a/internal/source/atsumaru_test.go
+++ b/internal/source/atsumaru_test.go
@@ -1,0 +1,211 @@
+package source
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"mangarr/internal/domain"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAtsumaruValidateInput(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		input   string
+		wantErr string
+	}{
+		{
+			name:  "valid URL",
+			input: "https://atsu.moe/manga/Q5Mqy",
+		},
+		{
+			name:    "empty input",
+			input:   "",
+			wantErr: "atsumaru manga URL is required",
+		},
+		{
+			name:    "raw ID rejected",
+			input:   "Q5Mqy",
+			wantErr: "the URL for Atsumaru must start with https://atsu.moe",
+		},
+		{
+			name:    "wrong host",
+			input:   "https://example.com/manga/Q5Mqy",
+			wantErr: "the URL for Atsumaru must start with https://atsu.moe",
+		},
+		{
+			name:    "wrong path",
+			input:   "https://atsu.moe/title/Q5Mqy",
+			wantErr: "invalid Atsumaru manga URL path",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			src := NewAtsumaru(tt.input, "scan-1")
+			err := src.ValidateInput()
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+
+			require.EqualError(t, err, tt.wantErr)
+		})
+	}
+}
+
+func TestAtsumaruValidateInputRequiresScanID(t *testing.T) {
+	t.Parallel()
+
+	src := NewAtsumaru("https://atsu.moe/manga/Q5Mqy", "")
+
+	err := src.ValidateInput()
+	require.EqualError(t, err, "atsumaru scan ID is required")
+}
+
+func TestAtsumaruGetManga(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/api/manga/info", r.URL.Path)
+		require.Equal(t, "Q5Mqy", r.URL.Query().Get("mangaId"))
+
+		fmt.Fprint(w, `{
+			"id": "Q5Mqy",
+			"title": "Kagurabachi",
+			"forceStrip": true,
+			"chapters": [
+				{"id": "chapter-0", "title": "Chapter 0", "number": 0, "scanId": "scan-1"},
+				{"id": "chapter-7-1", "title": "Chapter 7.1", "number": 7.1, "scanId": "scan-1"},
+				{"id": "chapter-7-1-other", "title": "Chapter 7.1", "number": 7.1, "scanId": "scan-2"}
+			]
+		}`)
+	}))
+	defer server.Close()
+
+	src := newTestAtsumaru(server.URL + "/manga/Q5Mqy")
+
+	manga, err := src.GetManga(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, "Q5Mqy", manga.ID)
+	require.Equal(t, server.URL+"/manga/Q5Mqy", manga.URL)
+	require.Equal(t, "Kagurabachi", manga.Title)
+	require.True(t, manga.IsManhwa)
+	require.Len(t, manga.Chapters, 2)
+
+	ch0, ok := manga.Chapters[domain.MustParseChapterNumber("0")]
+	require.True(t, ok)
+	require.Equal(t, "chapter-0", ch0.ID)
+	require.Equal(t, "Chapter 0", ch0.Title)
+
+	ch71, ok := manga.Chapters[domain.MustParseChapterNumber("7.1")]
+	require.True(t, ok)
+	require.Equal(t, "chapter-7-1", ch71.ID)
+	require.Equal(t, "Chapter 7.1", ch71.Title)
+}
+
+func TestAtsumaruGetMangaErrorsWhenScanIDHasNoChapters(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, `{
+			"id": "Q5Mqy",
+			"title": "Kagurabachi",
+			"chapters": [
+				{"id": "chapter-1", "title": "Chapter 1", "number": 1, "scanId": "scan-2"}
+			]
+		}`)
+	}))
+	defer server.Close()
+
+	src := newTestAtsumaru(server.URL + "/manga/Q5Mqy")
+
+	_, err := src.GetManga(t.Context())
+	require.EqualError(t, err, "getting chapters for manga Kagurabachi")
+}
+
+func TestAtsumaruGetMangaErrorsWhenNoChapters(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, `{"id":"Q5Mqy","title":"Kagurabachi","chapters":[]}`)
+	}))
+	defer server.Close()
+
+	src := newTestAtsumaru(server.URL + "/manga/Q5Mqy")
+
+	_, err := src.GetManga(t.Context())
+	require.EqualError(t, err, "getting chapters for manga Kagurabachi")
+}
+
+func TestAtsumaruGetImageURLs(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/api/read/chapter", r.URL.Path)
+		require.Equal(t, "Q5Mqy", r.URL.Query().Get("mangaId"))
+		require.Equal(t, "yzmwX4", r.URL.Query().Get("chapterId"))
+
+		fmt.Fprint(w, `{
+			"readChapter": {
+				"id": "yzmwX4",
+				"title": "Chapter 121",
+				"pages": [
+					{"image": "/static/pages/yzmwX4/0.webp"},
+					{"image": "https://cdn.atsu.test/static/pages/yzmwX4/1.webp"}
+				]
+			}
+		}`)
+	}))
+	defer server.Close()
+
+	src := newTestAtsumaru(server.URL + "/manga/Q5Mqy")
+	chapter := domain.Chapter{
+		ID:     "yzmwX4",
+		Number: domain.MustParseChapterNumber("121"),
+	}
+
+	err := src.GetImageURLs(t.Context(), &chapter)
+	require.NoError(t, err)
+	require.Len(t, chapter.ImageInfo, 2)
+	require.Equal(t, server.URL+"/static/pages/yzmwX4/0.webp", chapter.ImageInfo[0].ImageURL)
+	require.Equal(t, "https://cdn.atsu.test/static/pages/yzmwX4/1.webp", chapter.ImageInfo[1].ImageURL)
+}
+
+func TestAtsumaruGetImageURLsErrorsWhenNoPages(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, `{"readChapter":{"id":"yzmwX4","title":"Chapter 121","pages":[]}}`)
+	}))
+	defer server.Close()
+
+	src := newTestAtsumaru(server.URL + "/manga/Q5Mqy")
+	chapter := domain.Chapter{
+		ID:     "yzmwX4",
+		Number: domain.MustParseChapterNumber("121"),
+	}
+
+	err := src.GetImageURLs(t.Context(), &chapter)
+	require.EqualError(t, err, "getting image URLs for chapter ID yzmwX4")
+}
+
+func newTestAtsumaru(mangaURL string) *atsumaru {
+	return &atsumaru{
+		MangaURL: mangaURL,
+		ScanID:   "scan-1",
+		BaseURL:  strings.TrimSuffix(mangaURL, "/manga/Q5Mqy"),
+		Client: &http.Client{
+			Timeout: 10 * time.Second,
+		},
+	}
+}

--- a/internal/source/source.go
+++ b/internal/source/source.go
@@ -24,6 +24,8 @@ func Select(monitoredManga domain.MonitoredManga) (domain.Source, error) {
 		return NewWeebCentral(monitoredManga.Manga), nil
 	case "comix":
 		return NewComix(monitoredManga.Manga, monitoredManga.Group), nil
+	case "atsumaru":
+		return NewAtsumaru(monitoredManga.Manga, monitoredManga.Group), nil
 	}
 
 	return nil, fmt.Errorf("unknown monitored manga source %s", monitoredManga.Source)


### PR DESCRIPTION
## Summary
- add `atsumaru` source support for `https://atsu.moe/manga/...` URLs
- require `-g` as Atsu `scanId` to avoid duplicate chapter-number collisions
- document usage and add adapter regression coverage

## Test plan
- [x] `go test ./internal/source`
- [x] `go test ./...`
- [x] `go test -race ./...`
- [x] `go build ./...`
- [x] `go run . download -d /tmp/mangarr-atsumaru-smoke -s atsumaru -m https://atsu.moe/manga/Q5Mqy -g cmgzlsevifjhtm191rqugvee3 -L`
- [x] `go fix ./...`
- [ ] `govulncheck ./...` reports existing `GO-2026-4961` in `golang.org/x/image@v0.29.0`; follow-up planned
