### PR TITLE
fix(source): deprecate comix

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,11 @@ If you omit it, mangarr also checks common default locations. Full config and ov
 | [Asura Scans](https://asurascans.com/) | `asurascans` | full `https://asurascans.com/comics/...` URL | locked early-access chapters are skipped until public |
 | [Cubari](https://cubari.moe/) | `cubari` | gist URL | required `-g` group |
 | [Weeb Central](https://weebcentral.com/) | `weebcentral` | full `https://weebcentral.com/...` URL | none |
-| [Comix](https://comix.to/) | `comix` | full `https://comix.to/title/...` URL | optional `-g` group |
 | [Atsumaru](https://atsu.moe/) | `atsumaru` | full `https://atsu.moe/manga/...` URL | required `-g` scan ID |
+
+Deprecated sources:
+
+- `comix`: Comix chapter pages now require a browser-generated token, so mangarr fails fast instead of attempting brittle token scraping.
 
 ## More Docs
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -144,8 +144,11 @@ mangarr version
 | [Asura Scans](https://asurascans.com/) | `asurascans` | current `https://asurascans.com/comics/...` series URL | locked early-access chapters are skipped until public |
 | [Cubari](https://cubari.moe/) | `cubari` | gist URL | required `-g` group such as `/r/OnePunchMan` |
 | [Weeb Central](https://weebcentral.com/) | `weebcentral` | full series URL | none |
-| [Comix](https://comix.to/) | `comix` | full `https://comix.to/title/...` URL | optional `-g` group; default is official releases |
 | [Atsumaru](https://atsu.moe/) | `atsumaru` | full `https://atsu.moe/manga/...` URL | required `-g` scan ID |
+
+Deprecated sources:
+
+- `comix`: Comix chapter pages now require a browser-generated token, so mangarr fails fast instead of attempting brittle token scraping.
 
 For implementation-level source behavior and validation rules, see [design-docs/source-adapters.md](./design-docs/source-adapters.md).
 

--- a/docs/design-docs/source-adapters.md
+++ b/docs/design-docs/source-adapters.md
@@ -15,8 +15,13 @@ All adapters implement `domain.Source`.
 | `asurascans` | full series URL | none | `https://asurascans.com/comics/...` | server-rendered HTML; filters locked early-access chapters from discovery |
 | `cubari` | gist URL | `-g` required | valid URL + non-empty group | images resolved in payload |
 | `weebcentral` | full series URL | none | `https://weebcentral.com` prefix | scraper + chapter image fragment fetch |
-| `comix` | full title URL | `-g` optional | `https://comix.to/title` prefix | API-based |
 | `atsumaru` | full manga URL | `-g` required | `https://atsu.moe/manga/...` prefix + non-empty scan ID | API-based |
+
+Deprecated:
+
+| Identifier | Status | Reason |
+| --- | --- | --- |
+| `comix` | recognized but fails fast | chapter page access requires a browser-generated token from obfuscated site JavaScript |
 
 ## Rules
 

--- a/docs/exec-plans/completed/2026-05-19-comix-deprecation.md
+++ b/docs/exec-plans/completed/2026-05-19-comix-deprecation.md
@@ -1,0 +1,30 @@
+# Comix Deprecation
+
+## Problem
+
+Comix moved chapter page access behind a browser-generated token. The public v1 manga and chapter-list endpoints still work, but `GET /api/v1/chapters/{id}` returns `403` with `Missing token.` outside the site runtime.
+
+## Scope
+
+- Keep `comix` as a recognized source key.
+- Fail fast with a clear deprecation error.
+- Update source docs and user-facing source tables.
+- Add a regression test for the deprecation message.
+
+## Non-Goals
+
+- Reverse-engineer the token generator.
+- Add a browser-backed Comix adapter.
+- Remove the Comix source key in this change.
+
+## Decisions
+
+- Deprecate instead of repairing because token generation lives in obfuscated browser JavaScript and is likely to drift.
+- Keep the source selectable so existing configs produce a targeted error instead of an unknown-source error.
+
+## Verification
+
+- `go test ./internal/source`
+- `go test ./...`
+- `go test -race ./...`
+- `go build ./...`

--- a/internal/source/comix.go
+++ b/internal/source/comix.go
@@ -22,6 +22,7 @@ const (
 	comixResultLimit = 100
 
 	comixOfficialGroupID = "9275"
+	comixDeprecatedError = "Comix is deprecated because chapter pages now require a browser-generated token"
 )
 
 type comix struct {
@@ -154,15 +155,7 @@ func (c *comix) String() string {
 }
 
 func (c *comix) ValidateInput() error {
-	if !strings.HasPrefix(c.MangaURL, "https://comix.to/title") {
-		return fmt.Errorf("the URL for Comix must start with https://comix.to/title")
-	}
-
-	if _, err := url.Parse(c.MangaURL); err != nil {
-		return fmt.Errorf("parsing URL %s: %w", c.MangaURL, err)
-	}
-
-	return nil
+	return fmt.Errorf(comixDeprecatedError)
 }
 
 func (c *comix) GetManga(ctx context.Context) (domain.Manga, error) {

--- a/internal/source/comix_test.go
+++ b/internal/source/comix_test.go
@@ -1,0 +1,16 @@
+package source
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestComixValidateInputDeprecated(t *testing.T) {
+	t.Parallel()
+
+	src := NewComix("https://comix.to/title/pvry-one-piece", "")
+
+	err := src.ValidateInput()
+	require.EqualError(t, err, comixDeprecatedError)
+}


### PR DESCRIPTION
## Summary

- Deprecate Comix with a clear fail-fast source error.
- Move Comix out of supported source docs and record the deprecation rationale.
- Add regression coverage for the deprecation message.
