### PR TITLE
fix(source): resolve cubari proxy chapters

### DIFF
--- a/docs/design-docs/source-adapters.md
+++ b/docs/design-docs/source-adapters.md
@@ -13,7 +13,7 @@ All adapters implement `domain.Source`.
 | `mangaplus` | numeric title ID | none | strict numeric regex | mobile protobuf API; lazily registers a deterministic device secret |
 | `flamecomics` | full series URL | none | `https://flamecomics.xyz` prefix | HTML + embedded JSON |
 | `asurascans` | full series URL | none | `https://asurascans.com/comics/...` | server-rendered HTML; filters locked early-access chapters from discovery |
-| `cubari` | gist URL | `-g` required | valid URL + non-empty group | images resolved in payload |
+| `cubari` | gist URL | `-g` required | valid URL + non-empty group | images listed in the payload, or fetched from the `/proxy/...` path the gist points at |
 | `weebcentral` | full series URL | none | `https://weebcentral.com` prefix | scraper + chapter image fragment fetch |
 | `atsumaru` | full manga URL | `-g` required | `https://atsu.moe/manga/...` prefix + non-empty scan ID | API-based |
 

--- a/internal/source/cubari.go
+++ b/internal/source/cubari.go
@@ -16,9 +16,12 @@ import (
 	"github.com/avast/retry-go"
 )
 
+const cubariURL = "https://cubari.moe"
+
 type cubari struct {
 	MangaURL string
 	GroupID  string
+	BaseURL  string
 	Client   *http.Client
 }
 
@@ -43,6 +46,7 @@ func NewCubari(mangaURL, groupID string) domain.Source {
 	return &cubari{
 		MangaURL: mangaURL,
 		GroupID:  groupID,
+		BaseURL:  cubariURL,
 		Client:   &client,
 	}
 }
@@ -66,36 +70,13 @@ func (c *cubari) ValidateInput() error {
 func (c *cubari) GetManga(ctx context.Context) (domain.Manga, error) {
 	var cubariResp cubariResponse
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.MangaURL, nil)
-	if err != nil {
-		return domain.Manga{}, fmt.Errorf("creating request: %w", err)
-	}
-
-	req.Header.Set("User-Agent", "mangarr")
-
-	retryErr := retry.Do(func() error {
-		resp, err := sharedhttp.ExecRequest(*c.Client, req)
-		if err != nil {
-			return err
-		}
-		defer resp.Body.Close()
-
-		err = json.NewDecoder(resp.Body).Decode(&cubariResp)
-		if err != nil {
-			return retry.Unrecoverable(fmt.Errorf("decoding response: %w", err))
-		}
-
-		return nil
-	},
-		sharedhttp.RetryOptions(ctx)...,
-	)
-	if retryErr != nil {
-		return domain.Manga{}, fmt.Errorf("executing request %s: %w", req.URL, retryErr)
+	if err := c.fetchJSON(ctx, c.MangaURL, &cubariResp); err != nil {
+		return domain.Manga{}, err
 	}
 
 	title := cubariResp.Title
 	if len(title) == 0 {
-		return domain.Manga{}, fmt.Errorf("getting manga for URL %s", req.URL)
+		return domain.Manga{}, fmt.Errorf("getting manga for URL %s", c.MangaURL)
 	}
 
 	manga := domain.Manga{
@@ -118,8 +99,8 @@ func (c *cubari) GetManga(ctx context.Context) (domain.Manga, error) {
 			continue
 		}
 
-		var imageURLs []string
-		if err := json.Unmarshal(rawURLs, &imageURLs); err != nil {
+		imageURLs, err := c.chapterImageURLs(ctx, rawURLs)
+		if err != nil {
 			return domain.Manga{}, fmt.Errorf("decoding chapter %s image URLs for group %s: %w", num, c.GroupID, err)
 		}
 		if len(imageURLs) == 0 {
@@ -143,6 +124,75 @@ func (c *cubari) GetManga(ctx context.Context) (domain.Manga, error) {
 	}
 
 	return manga, nil
+}
+
+// chapterImageURLs resolves a group entry, which Cubari gists write either as a
+// list of image URLs or as a proxy path that has to be fetched to get that list.
+func (c *cubari) chapterImageURLs(ctx context.Context, raw json.RawMessage) ([]string, error) {
+	var proxyPath string
+	if err := json.Unmarshal(raw, &proxyPath); err != nil {
+		var imageURLs []string
+		if err := json.Unmarshal(raw, &imageURLs); err != nil {
+			return nil, err
+		}
+
+		return imageURLs, nil
+	}
+
+	proxyURL, err := c.proxyURL(proxyPath)
+	if err != nil {
+		return nil, err
+	}
+
+	var imageURLs []string
+	if err := c.fetchJSON(ctx, proxyURL, &imageURLs); err != nil {
+		return nil, err
+	}
+
+	return imageURLs, nil
+}
+
+func (c *cubari) proxyURL(path string) (string, error) {
+	if strings.HasPrefix(path, "http://") || strings.HasPrefix(path, "https://") {
+		return path, nil
+	}
+
+	proxyURL, err := url.JoinPath(c.BaseURL, path)
+	if err != nil {
+		return "", fmt.Errorf("building proxy URL for %s: %w", path, err)
+	}
+
+	return proxyURL, nil
+}
+
+func (c *cubari) fetchJSON(ctx context.Context, rawURL string, target any) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return fmt.Errorf("creating request: %w", err)
+	}
+
+	req.Header.Set("User-Agent", "mangarr")
+
+	retryErr := retry.Do(func() error {
+		resp, err := sharedhttp.ExecRequest(*c.Client, req)
+		if err != nil {
+			return err
+		}
+		defer resp.Body.Close()
+
+		if err := json.NewDecoder(resp.Body).Decode(target); err != nil {
+			return retry.Unrecoverable(fmt.Errorf("decoding response: %w", err))
+		}
+
+		return nil
+	},
+		sharedhttp.RetryOptions(ctx)...,
+	)
+	if retryErr != nil {
+		return fmt.Errorf("executing request %s: %w", req.URL, retryErr)
+	}
+
+	return nil
 }
 
 func (c *cubari) GetChapters(_ context.Context, _ domain.Manga) error {

--- a/internal/source/cubari_test.go
+++ b/internal/source/cubari_test.go
@@ -1,0 +1,63 @@
+package source
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"mangarr/internal/domain"
+
+	"github.com/stretchr/testify/require"
+)
+
+func newTestCubari(mangaURL, baseURL string) *cubari {
+	return &cubari{
+		MangaURL: mangaURL,
+		GroupID:  "The Koi Pond",
+		BaseURL:  baseURL,
+		Client: &http.Client{
+			Timeout: 10 * time.Second,
+		},
+	}
+}
+
+func TestCubariGetMangaProxyChapter(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/gist":
+			fmt.Fprint(w, `{
+				"title": "One Punch Man",
+				"chapters": {
+					"235": {"title": "Chapter 235: Inline", "groups": {"The Koi Pond": ["https://cdn.example.com/a.png"]}},
+					"236": {"title": "Chapter 236: Part-Time Bro 2", "groups": {"The Koi Pond": "/proxy/api/imgchest/chapter/a846bgrj2yx"}}
+				}
+			}`)
+		case "/proxy/api/imgchest/chapter/a846bgrj2yx":
+			fmt.Fprint(w, `["https://cdn.imgchest.com/files/1cac361a319f.png", "https://cdn.imgchest.com/files/512b2631f5df.png"]`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	src := newTestCubari(server.URL+"/gist", server.URL)
+
+	manga, err := src.GetManga(t.Context())
+	require.NoError(t, err)
+
+	chapter, ok := manga.Chapters[domain.ChapterNumber{Whole: 236}]
+	require.True(t, ok, "chapter 236 missing")
+	require.Equal(t, "Part-Time Bro 2", chapter.Title)
+	require.Equal(t, []domain.ImageInfo{
+		{ImageURL: "https://cdn.imgchest.com/files/1cac361a319f.png"},
+		{ImageURL: "https://cdn.imgchest.com/files/512b2631f5df.png"},
+	}, chapter.ImageInfo)
+
+	inline, ok := manga.Chapters[domain.ChapterNumber{Whole: 235}]
+	require.True(t, ok, "chapter 235 missing")
+	require.Equal(t, []domain.ImageInfo{{ImageURL: "https://cdn.example.com/a.png"}}, inline.ImageInfo)
+}


### PR DESCRIPTION
## Problem

Fetching One Punch Man from Cubari failed outright:

```
decoding chapter 236 image URLs for group The Koi Pond: json: cannot unmarshal string into Go value of type []string
```

The gist format lets a chapter's group be either a list of image URLs or a proxy path that has to be fetched to get that list. `GetManga` only ever unmarshalled into `[]string`, so the string form errored. Since the error aborts the loop over all chapters, one such chapter took down the whole manga fetch. In `KokiKoi/KoiPondManga/OPM.json` that is exactly one chapter out of fifteen: `"The Koi Pond": "/proxy/api/imgchest/chapter/a846bgrj2yx"`.

## Fix

`chapterImageURLs` tries the string form first and, on a match, resolves it against a new `BaseURL` field (defaults to `https://cubari.moe`, absolute URLs pass through unchanged) and fetches the array from there. Chapters that already carry an inline list take the same path as before, so the common case is untouched and costs no extra request. The request/decode/retry block moved into a `fetchJSON` helper so the proxy fetch inherits the same retry policy, timeout and User-Agent as the gist fetch.

## Tests

- New `TestCubariGetMangaProxyChapter` serves a gist with one inline chapter and one proxy chapter over `httptest`, plus the proxy endpoint. It fails on the old code with the exact error above.
- Checked against the live gist before merging: chapter 236 resolves to 18 images, and the other 14 chapters keep working.

Also updates the source-adapters doc, which claimed Cubari images are always resolved in the payload.