### PR TITLE
chore: ignore .DS_Store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ go.work
 .idea/
 .vscode/
 dist/
+.DS_Store


### PR DESCRIPTION
## Why

macOS writes `.DS_Store` into any directory it browses, so one turned up as untracked in `internal/` and would keep coming back. Nothing tracked in the repo is affected.

## What changed

Adds `.DS_Store` to `.gitignore` alongside the other editor and OS entries.