### PR TITLE
fix: resolve relative Weeb Central chapter URLs

### DIFF
--- a/internal/source/weebcentral.go
+++ b/internal/source/weebcentral.go
@@ -112,7 +112,12 @@ func (w *weebcentral) GetChapters(_ context.Context, manga domain.Manga) error {
 	})
 
 	c.OnHTML("a.flex", func(e *colly.HTMLElement) {
-		chapterURL := e.Attr("href")
+		chapterURL, err := resolveAgainstBase(w.BaseURL, e.Attr("href"))
+		if err != nil {
+			errors = append(errors, fmt.Errorf("resolving chapter URL: %w", err))
+			return
+		}
+
 		name := e.ChildText("span.grow")
 		number, err := w.getChapterNumber(name)
 		if err != nil {

--- a/internal/source/weebcentral_test.go
+++ b/internal/source/weebcentral_test.go
@@ -53,6 +53,36 @@ func TestWeebCentralGetImageURLsExtractsChapterAssets(t *testing.T) {
 	require.Equal(t, server.URL+"/media/chapter-002.png", chapter.ImageInfo[1].ImageURL)
 }
 
+func TestWeebCentralResolvesRelativeChapterURLs(t *testing.T) {
+	t.Parallel()
+
+	const chapterPath = "/chapters/01RELATIVECHAPTER"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/series/series-id/full-chapter-list":
+			fmt.Fprintf(w, `<a class="flex" href="%s"><span class="grow">Chapter 356</span></a>`, chapterPath)
+		case chapterPath + "/images":
+			fmt.Fprint(w, `<img src="/media/chapter-356.png" />`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	src := newTestWeebCentral(server.URL+"/series/series-id", server.URL)
+	chapterNumber := domain.MustParseChapterNumber("356")
+	manga := domain.Manga{
+		Title:    "Blue Lock",
+		Chapters: make(map[domain.ChapterNumber]domain.Chapter),
+	}
+
+	require.NoError(t, src.GetChapters(t.Context(), manga))
+	chapter := manga.Chapters[chapterNumber]
+	require.NoError(t, src.GetImageURLs(t.Context(), &chapter))
+	require.Equal(t, server.URL+"/media/chapter-356.png", chapter.ImageInfo[0].ImageURL)
+}
+
 func TestWeebCentralGetImageURLsErrorsWhenFragmentHasNoImages(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Problem

Weeb Central chapter discovery can return root-relative links such as `/chapters/01KZ6NCEYRSZSR4G8XVDS1GBPR`. The adapter stored those links unchanged, so its image request remained relative and failed with `unsupported protocol scheme ""`.

## Fix

Resolve chapter links against the Weeb Central base URL during discovery. Existing absolute links remain unchanged, while relative links become valid HTTP request targets before image extraction.

## Tests

- Added an adapter regression that discovers a relative chapter link, fetches its image fragment, and verifies the resulting absolute image URL.
