### PR TITLE
feat(source): restore Comix support

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,11 +83,10 @@ If you omit it, mangarr also checks common default locations. Full config and ov
 | [Asura Scans](https://asurascans.com/) | `asurascans` | full `https://asurascans.com/comics/...` URL | locked early-access chapters are skipped until public |
 | [Cubari](https://cubari.moe/) | `cubari` | gist URL | required `-g` group |
 | [Weeb Central](https://weebcentral.com/) | `weebcentral` | full `https://weebcentral.com/...` URL | none |
+| [Comix](https://comix.to/) | `comix` | full `https://comix.to/title/...` URL | optional `-g` numeric group ID |
 | [Atsumaru](https://atsu.moe/) | `atsumaru` | full `https://atsu.moe/manga/...` URL | required `-g` scan ID |
 
-Deprecated sources:
-
-- `comix`: Comix chapter pages now require a browser-generated token, so mangarr fails fast instead of attempting brittle token scraping.
+Comix uses a private frontend protocol. A Comix frontend update can require a Mangarr update.
 
 ## More Docs
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -144,11 +144,10 @@ mangarr version
 | [Asura Scans](https://asurascans.com/) | `asurascans` | current `https://asurascans.com/comics/...` series URL | locked early-access chapters are skipped until public |
 | [Cubari](https://cubari.moe/) | `cubari` | gist URL | required `-g` group such as `/r/OnePunchMan` |
 | [Weeb Central](https://weebcentral.com/) | `weebcentral` | full series URL | none |
+| [Comix](https://comix.to/) | `comix` | full `https://comix.to/title/...` URL | optional `-g` numeric group ID |
 | [Atsumaru](https://atsu.moe/) | `atsumaru` | full `https://atsu.moe/manga/...` URL | required `-g` scan ID |
 
-Deprecated sources:
-
-- `comix`: Comix chapter pages now require a browser-generated token, so mangarr fails fast instead of attempting brittle token scraping.
+Comix uses a private frontend protocol. Mangarr generates request tokens, decodes API responses, sends the required image referer, and reconstructs scrambled image tiles. A Comix frontend update can require a Mangarr update. Use `-g` when a title has duplicate chapter numbers from different groups.
 
 For implementation-level source behavior and validation rules, see [design-docs/source-adapters.md](./design-docs/source-adapters.md).
 

--- a/docs/design-docs/source-adapters.md
+++ b/docs/design-docs/source-adapters.md
@@ -1,6 +1,6 @@
 # Source Adapters
 
-Verified against `internal/source/` on 2026-05-24.
+Verified against `internal/source/` on 2026-08-07.
 
 All adapters implement `domain.Source`.
 
@@ -15,13 +15,8 @@ All adapters implement `domain.Source`.
 | `asurascans` | full series URL | none | `https://asurascans.com/comics/...` | server-rendered HTML; filters locked early-access chapters from discovery |
 | `cubari` | gist URL | `-g` required | valid URL + non-empty group | images listed in the payload, or fetched from the `/proxy/...` path the gist points at |
 | `weebcentral` | full series URL | none | `https://weebcentral.com` prefix | scraper + chapter image fragment fetch |
+| `comix` | full manga URL | `-g` optional | `https://comix.to/title/...` prefix; numeric group when set | private API codec + referer-protected images + tile reconstruction |
 | `atsumaru` | full manga URL | `-g` required | `https://atsu.moe/manga/...` prefix + non-empty scan ID | API-based |
-
-Deprecated:
-
-| Identifier | Status | Reason |
-| --- | --- | --- |
-| `comix` | recognized but fails fast | chapter page access requires a browser-generated token from obfuscated site JavaScript |
 
 ## Rules
 
@@ -37,6 +32,8 @@ Deprecated:
 - `mangaplus` uses the mobile API because the web protobuf endpoint rejects current unauthenticated access; chapter discovery reads the current `chapter_list_v2` field with legacy list fields kept as fallback
 - `asurascans` removes chapters marked `is_locked=true` before returning the chapter map
 - `weebcentral` fetches chapter images from the `/chapters/<id>/images` HTML fragment
+- `comix` implements frontend build `35595e3de3c99889c1aa70`; it generates request tokens, decodes encrypted API envelopes, sends image request headers, and reconstructs scrambled tile images
 - `atsumaru` fetches chapter metadata from `/api/manga/info`, filters chapters by scan ID, and resolves relative page paths from `/api/read/chapter`
+- source-specific image transforms use `domain.ImageProcessor`; the downloader owns transport and output while the source adapter owns the transform
 - retry policy comes from `internal/sharedhttp/`
 - manhwa/long-strip handling flows through `selectedManga.IsManhwa`

--- a/docs/exec-plans/completed/2026-08-07-comix-protocol-restoration.md
+++ b/docs/exec-plans/completed/2026-08-07-comix-protocol-restoration.md
@@ -1,0 +1,66 @@
+# Comix Protocol Restoration
+
+## Problem
+
+The Comix adapter targeted removed `/api/v2` endpoints and was disabled because current
+API requests require a frontend-generated token. Research against frontend build
+`35595e3de3c99889c1aa70` recovered request-token generation, encrypted-response decoding,
+and scrambled-image reconstruction.
+
+## Scope
+
+- Add a source-local implementation of the current request and response codec.
+- Move the Comix adapter to current `/api/v1` response shapes.
+- Send required image request headers and reconstruct scrambled tile images.
+- Add regression tests for protocol vectors, adapter behavior, image transport, and both
+  tile-order algorithms.
+- Restore Comix as a supported source with an explicit compatibility warning.
+
+## Non-Goals
+
+- Do not disguise Mangarr traffic or bypass account authentication.
+- Do not enable signed-in Comix endpoints.
+- Do not add automatic extraction of future frontend constants.
+
+## Decisions
+
+- Keep build-specific token and image behavior in `internal/source/`.
+- Add `domain.ImageProcessor` as a narrow source-owned image transform seam. The downloader
+  owns transport and output, but it does not import Comix behavior.
+- Use fixed local fixtures for normal tests. Live Comix requests remain a manual smoke test.
+- Treat `403` and `429` as unrecoverable through the existing shared HTTP policy.
+- Keep optional numeric group selection. Without a group, the first duplicate chapter in
+  server order wins because the domain chapter map has one value per chapter number.
+
+## Completed Work
+
+- [x] Reproduce the current request token from a fixed frontend vector.
+- [x] Decode encrypted API response envelopes.
+- [x] Port both embedded WebAssembly tile-order algorithms to pure Go.
+- [x] Normalize direct and compact page payloads.
+- [x] Send per-image referer headers and reconstruct scrambled pages as PNG.
+- [x] Update source and user documentation.
+
+## Verification
+
+- `go test ./internal/domain ./internal/download ./internal/source -count=1`
+- `go test ./...`
+- `go test -race ./...`
+- `go build ./...`
+- `go vet ./...`
+- `govulncheck ./...`: no vulnerabilities found
+- `deadcode ./...`: no new Comix findings; it reported existing browser helpers,
+  `MustParseChapterNumber`, and `CreatePDF`
+- Live API smoke: title metadata, two-item chapter list, and chapter detail all returned and
+  decoded through the Go implementation.
+- Live CLI smoke: downloaded One Piece chapter 1190 from group `6594`, reconstructed its one
+  scrambled page, wrote a 16-page CBZ, and passed `unzip -t` for every archive entry.
+- Visual smoke: the reconstructed live page had coherent panels, text, and tile boundaries.
+
+## Follow-Up Debt
+
+- Frontend build drift can rotate token constants, response handling, hash prefixes, or tile
+  algorithms without notice.
+- Signed-in and mutation endpoints remain unsupported and untested.
+- The domain chapter map still cannot represent duplicate chapter numbers from multiple
+  groups at the same time.

--- a/docs/exec-plans/completed/README.md
+++ b/docs/exec-plans/completed/README.md
@@ -4,3 +4,4 @@ Completed plans kept in-repo:
 
 - [2026-03-07-chapter-number-refactor.md](./2026-03-07-chapter-number-refactor.md)
 - [2026-03-07-doc-knowledge-base-restructure.md](./2026-03-07-doc-knowledge-base-restructure.md)
+- [2026-08-07-comix-protocol-restoration.md](./2026-08-07-comix-protocol-restoration.md)

--- a/docs/research/comix-api.md
+++ b/docs/research/comix-api.md
@@ -1,0 +1,177 @@
+# Comix API Research
+
+Research date: 2026-08-07
+
+## Decision
+
+Restore the Comix adapter with an explicit compatibility warning.
+
+Comix has a usable private web API, but it does not expose a stable public API. Mangarr now implements the request token, encrypted response envelope, image referer, and tile reconstruction used by frontend build `35595e3de3c99889c1aa70`. This works without a browser, but it remains coupled to private implementation details that Comix can change without notice.
+
+## Scope and evidence
+
+This note uses first-party sources only:
+
+- live Comix pages and API responses
+- the current Comix frontend bundles
+- browser-observed requests made by the Comix frontend
+- Comix `robots.txt`, upload rules, credits, and contact pages
+- Mangarr source, domain, browser, and downloader contracts
+
+The inspected frontend build identifier was `35595e3de3c99889c1aa70`. Bundle names and behavior can change without notice. Comix did not publish source maps at the adjacent `.map` URL during this research.
+
+## Endpoint summary
+
+The current frontend configures an Axios client with base URL `/api/v1`, a 15-second timeout, `withCredentials: true`, `Accept: application/json`, and `X-Requested-With: XMLHttpRequest`. It installs a request interceptor from an obfuscated security module. [Current API client bundle](https://comix.to/assets/build/35595e3de3c99889c1aa70/dist/env-tjdqki-WSjnHwGH.js) [Current security bundle](https://comix.to/assets/build/35595e3de3c99889c1aa70/dist/secure-tjdqki-DZP4UvtB.js)
+
+| Operation | Current request | Access and response behavior |
+| --- | --- | --- |
+| Search/list titles | `GET /api/v1/manga?keyword={text}&limit={n}` | Protected by `_` token. The home search also sends repeated `content_rating[]` values. |
+| Title metadata | `GET /api/v1/manga/{hid}` | Protected by `_` token. The public title HTML also contains metadata in `#initial-data`. |
+| Title groups | `GET /api/v1/manga/{hid}/groups` | Declared by the current client. The title HTML also includes the group list in `#initial-data`. |
+| Chapter list | `GET /api/v1/manga/{hid}/chapters` | Protected by `_` token. Supports page, limit, ordering, group, number, and reader-centered queries. |
+| Chapter detail and pages | `GET /api/v1/chapters/{numericChapterID}` | Protected by `_` token. The response supplies chapter metadata and page data. |
+| Anonymous user state | `GET /api/v1/user` | Returned `200` with `{"status":"ok","result":null}` and set a two-hour anonymous session cookie in a direct logged-out request. |
+
+The client endpoint declarations are in the [current API client bundle](https://comix.to/assets/build/35595e3de3c99889c1aa70/dist/env-tjdqki-WSjnHwGH.js). The reader calls `/chapters/{id}` and normalizes the two page payload forms in the [current reader bundle](https://comix.to/assets/build/35595e3de3c99889c1aa70/dist/ReadPage-tjdqki-DcYDg-eV.js).
+
+The old Mangarr `/api/v2` paths now return `404`. Direct calls to the current title, search, chapter-list, and chapter-detail endpoints without `_` return `403` and `{"message":"Missing token."}`. Browser calls from the site add `_={opaque-value}` and return `200`. Replaying a browser URL worked, but changing its `page` parameter while keeping the token returned `403` and `{"message":"Invalid token."}`. The token is therefore bound to at least the route and query. [Example title endpoint](https://comix.to/api/v1/manga/pvry) [Example chapter-list endpoint](https://comix.to/api/v1/manga/pvry/chapters?page=1&limit=2) [Example chapter endpoint](https://comix.to/api/v1/chapters/11169424)
+
+Successful protected responses observed through the browser used `Content-Type: application/json`, `x-enc: 1`, and an encrypted body shaped as `{"e":"<opaque data>"}`. The frontend response interceptor returns decoded application objects to React. [Current API client bundle](https://comix.to/assets/build/35595e3de3c99889c1aa70/dist/env-tjdqki-WSjnHwGH.js) [Current security bundle](https://comix.to/assets/build/35595e3de3c99889c1aa70/dist/secure-tjdqki-DZP4UvtB.js)
+
+## Authentication, cookies, and headers
+
+Reader access did not require a signed-in account. The logged-out frontend fetched title, chapter-list, and chapter-detail data successfully. It still uses credentialed same-origin requests and establishes an anonymous `session` cookie. An implementation must therefore preserve a cookie jar even if it does not support user login. [Comix home](https://comix.to/) [Current API client bundle](https://comix.to/assets/build/35595e3de3c99889c1aa70/dist/env-tjdqki-WSjnHwGH.js)
+
+Observed API request headers:
+
+```http
+Accept: application/json
+Referer: https://comix.to/title/<hid>-<slug>
+User-Agent: <browser user agent>
+X-Requested-With: XMLHttpRequest
+```
+
+There was no `Authorization` header. The protected requests placed the opaque value in the `_` query parameter.
+
+The site supports account login and registration, and those forms use Cloudflare Turnstile. This authentication is for user functions, not basic reader access. [Comix home](https://comix.to/) [Current main bundle](https://comix.to/assets/build/35595e3de3c99889c1aa70/dist/main-tjdqki-DltojfL5.js)
+
+## Search and title metadata
+
+The home search issued this request while logged out:
+
+```http
+GET /api/v1/manga?keyword=One+Piece&limit=6&content_rating[]=safe&content_rating[]=suggestive&_=<redacted>
+```
+
+The frontend also uses the same endpoint for browse results with `page`, `limit`, type, status, tag, and order parameters. List responses expose an `items` collection and pagination metadata. The current UI reads `total`, `perPage`, `page`, `lastPage`, `from`, `to`, `hasNext`, and `hasPrev`. [Comix home](https://comix.to/) [Current main bundle](https://comix.to/assets/build/35595e3de3c99889c1aa70/dist/main-tjdqki-DltojfL5.js) [Current API client bundle](https://comix.to/assets/build/35595e3de3c99889c1aa70/dist/env-tjdqki-WSjnHwGH.js)
+
+A title URL has this form:
+
+```text
+/title/{hid}-{slug}
+```
+
+For example, the One Piece page uses hash ID `pvry` and numeric internal ID `366`. Its server-rendered `#initial-data` object includes `id`, `hid`, `title`, alternative titles, type, status, language, poster URLs, latest and final chapter values, chapter availability, dates, synopsis, content rating, external links, and first/latest chapter URLs. It also includes the title's scanlation groups. [Example title page](https://comix.to/title/pvry-one-piece)
+
+Use `hid` as `domain.Manga.ID`. It is the API and URL identifier. Treat the numeric manga ID as secondary metadata. The human-readable slug is not an identifier and can change when the title changes.
+
+## Chapter listing and pagination
+
+The title page issued this request:
+
+```http
+GET /api/v1/manga/pvry/chapters?page=1&limit=20&order[number]=desc&_=<redacted>
+```
+
+The UI also sends these optional parameters:
+
+- `group_id={numericGroupID}`
+- `number={chapterNumber}`
+- `around={numericChapterID}` for a reader-centered page
+- `order[number]=asc|desc`
+
+The UI reads `items` and pagination metadata, including `page` and `lastPage`. It uses page numbers, not cursors. [Example title page](https://comix.to/title/pvry-one-piece) [Current main bundle](https://comix.to/assets/build/35595e3de3c99889c1aa70/dist/main-tjdqki-DltojfL5.js) [Current reader bundle](https://comix.to/assets/build/35595e3de3c99889c1aa70/dist/ReadPage-tjdqki-DcYDg-eV.js)
+
+Chapter links use this form:
+
+```text
+/title/{hid}-{slug}/{numericChapterID}-chapter-{chapterNumber}
+```
+
+The numeric chapter ID is stable enough for the chapter-detail endpoint. A title can contain duplicate chapter numbers from different groups. For example, the live One Piece list contained two chapter 1189 entries with different IDs and groups. Mangarr's `map[domain.ChapterNumber]domain.Chapter` cannot represent both. A Comix adapter must require a group ID or apply a documented deterministic preference before it fills that map. [Example title page](https://comix.to/title/pvry-one-piece)
+
+## Chapter pages and image retrieval
+
+The chapter HTML supplies only `mangaId`, `mangaHid`, `chapterId`, and `chapterNumber` in its server-rendered `#initial-data`. It does not supply page URLs. The reader fetches them from `/api/v1/chapters/{numericChapterID}` after startup. [Example reader page](https://comix.to/title/pvry-one-piece/11169424-chapter-1190) [Current reader bundle](https://comix.to/assets/build/35595e3de3c99889c1aa70/dist/ReadPage-tjdqki-DcYDg-eV.js)
+
+The frontend supports two decoded page forms:
+
+```json
+{"pages":[{"url":"https://<image-host>/<opaque-path>","width":800,"height":1200}]}
+```
+
+or:
+
+```json
+{
+  "pages": {
+    "baseUrl": "https://<image-host>",
+    "items": [
+      {"url":"/<opaque-path>","width":800,"height":1200,"s":1}
+    ]
+  }
+}
+```
+
+For the compact form, concatenate `baseUrl` and each item URL in listed order. `s: 1` marks a scrambled image. The reader passes such images to an obfuscated function and renders the result to a canvas. It uses a normal `<img>` only when the scramble flag is absent. [Current reader bundle](https://comix.to/assets/build/35595e3de3c99889c1aa70/dist/ReadPage-tjdqki-DcYDg-eV.js) [Current security bundle](https://comix.to/assets/build/35595e3de3c99889c1aa70/dist/secure-tjdqki-DZP4UvtB.js)
+
+One current chapter returned 16 page entries and used normal images. Its page host rejected a Mangarr-like request without a referer with `403`, then returned `200 image/webp` when the request used `Referer: https://comix.to/`. The successful response allowed byte ranges and exposed scramble-related header names through CORS. The page host is external to `comix.to`, so it is operational evidence, not a first-party policy source. The first-party reader generated these URLs and sent the root Comix referer. [Example reader page](https://comix.to/title/pvry-one-piece/11169424-chapter-1190) [Current reader bundle](https://comix.to/assets/build/35595e3de3c99889c1aa70/dist/ReadPage-tjdqki-DcYDg-eV.js)
+
+## Rate limits and anti-bot behavior
+
+Comix is served through Cloudflare. Pages include Cloudflare challenge code, and account forms use Turnstile. Protected API calls require the obfuscated `_` token. These are active anti-automation controls. [Comix home](https://comix.to/) [Current main bundle](https://comix.to/assets/build/35595e3de3c99889c1aa70/dist/main-tjdqki-DltojfL5.js) [Current security bundle](https://comix.to/assets/build/35595e3de3c99889c1aa70/dist/secure-tjdqki-DZP4UvtB.js)
+
+No rate-limit policy or quota was found. Sample `200`, `403`, and `404` responses did not include standard limit, remaining, reset, or `Retry-After` headers. The frontend has a generic message for HTTP `429`, but it does not document when Comix returns it. No load test was run. [Current main bundle](https://comix.to/assets/build/35595e3de3c99889c1aa70/dist/main-tjdqki-DltojfL5.js)
+
+An adapter must use low concurrency, cache title and chapter results, stop on `403` and `429`, and avoid retry storms. Mangarr already treats `403` and `429` as unrecoverable in `internal/sharedhttp`.
+
+## Legal and operational risks
+
+Comix does not expose API documentation or an API license in the current site navigation. The `/terms` and `/privacy` routes returned `404` during this research. The visible policy-related pages were Contact, Credits, Upload Request, and Upload Rules. [Comix home](https://comix.to/) [Contact](https://comix.to/contact) [Credits](https://comix.to/credits) [Upload rules](https://comix.to/upload-rules)
+
+`robots.txt` generally allows crawling, but it blocks several named AI crawlers. Its content signal permits search indexing and reference use, and rejects AI training. This file is not an API license or permission to redistribute chapter images. [Comix robots.txt](https://comix.to/robots.txt)
+
+The upload rules permit official releases and do not prohibit uploads of material that is restricted elsewhere. The credits page names other aggregators and scanlation groups as content sources. This creates material copyright, provenance, and availability risk for a downloader integration. Mangarr keeps its personal-use warning and must not imply that Comix grants redistribution rights. Distribution decisions can still require legal review. [Upload rules](https://comix.to/upload-rules) [Credits](https://comix.to/credits)
+
+The technical controls are also an operational warning. Reproducing the obfuscated token, decryptor, or descrambler would couple Mangarr to code that Comix can change on every build. A browser-backed implementation would add browser startup cost, larger failure scope, and ongoing maintenance for Cloudflare, lazy loading, and canvas output.
+
+## Mangarr adapter mapping
+
+The implementation uses this mapping:
+
+| Mangarr operation | Comix mapping | Required handling |
+| --- | --- | --- |
+| `ValidateInput` | Full `https://comix.to/title/{hid}-{slug}` URL | Validate scheme and host. Extract `hid`. Reject URLs without a title path. |
+| `GetManga` | Title HTML `#initial-data` or `GET /api/v1/manga/{hid}` | Map `hid` to `Manga.ID`, sanitized title to `Manga.Title`, and `manhwa` or `manhua` type to `Manga.IsManhwa`. |
+| `GetChapters` | `GET /api/v1/manga/{hid}/chapters` | Follow `page` through `lastPage`. Filter by configured numeric group ID before writing the chapter map. Map numeric chapter ID, number, title, and reader URL. |
+| `GetImageURLs` | `GET /api/v1/chapters/{numericChapterID}` | Preserve page order. Normalize direct and compact page formats. Carry referer requirements and scramble metadata. |
+| Image download | External page URL | Send the required Comix referer. Apply the header-driven tile transform for scrambled pages. |
+
+Current implementation status:
+
+- `internal/source/comix_protocol.go` generates `_` and decodes encrypted API envelopes.
+- `internal/source/comix_image.go` implements both frontend tile-order algorithms and writes reconstructed pages as PNG.
+- `domain.ImageInfo` carries per-image headers and an optional source-owned processor.
+- `internal/download` applies request headers and processors without importing Comix behavior.
+- `domain.Manga.Chapters` still cannot represent duplicate chapter numbers. An optional numeric group ID selects one group; without it, the first chapter in server order wins.
+
+## Maintenance conditions
+
+Keep Comix enabled only while these conditions remain true:
+
+1. Fixed vectors continue to match the current frontend request and image algorithms.
+2. The API response shapes remain compatible with the adapter fixtures.
+3. `403` and `429` remain unrecoverable, so protocol drift and rate limits do not cause retry storms.
+4. A live smoke test can fetch metadata, paginate chapters, download every page, reconstruct scrambled pages, and open the final archive.
+5. User documentation continues to warn that Comix uses a private protocol and can require prompt adapter updates.

--- a/docs/research/comix-token-reverse-engineering.md
+++ b/docs/research/comix-token-reverse-engineering.md
@@ -1,0 +1,153 @@
+# Comix Request Token Reverse Engineering
+
+Research date: 2026-08-07
+
+## Result
+
+The current Comix `_` request token is fully reproducible without a browser. It is a deterministic encoding of the normalized API path and canonical query parameters. It does not include time, randomness, cookies, the user agent, request headers, or the HTTP method.
+
+A pure Go implementation is feasible for frontend build `35595e3de3c99889c1aa70`. It would still be coupled to six hard-coded values in the current obfuscated bundle. Comix can rotate those values or change the algorithm in any frontend build.
+
+This note describes the current behavior implemented by the Mangarr adapter.
+
+## Sources
+
+Only current first-party code and live Comix responses were used:
+
+- [security bundle](https://comix.to/assets/build/35595e3de3c99889c1aa70/dist/secure-tjdqki-DZP4UvtB.js), SHA-256 `27ca58cb8a3cb09968dead4edd726a847ee718e0678c865a927164952e32e76f`
+- [API client bundle](https://comix.to/assets/build/35595e3de3c99889c1aa70/dist/env-tjdqki-WSjnHwGH.js), SHA-256 `9d83388e88eff9d6b55709eadffaf151e4811907cd72f4cbb47b844ae61bec66`
+- [reader bundle](https://comix.to/assets/build/35595e3de3c99889c1aa70/dist/ReadPage-tjdqki-DcYDg-eV.js), SHA-256 `588fa873576087d8d71f1a5aac5f1dba4d6e309281097257f92a7f5369b14330`
+- [live chapter-list endpoint](https://comix.to/api/v1/manga/pvry/chapters?page=1&limit=2)
+- [live chapter endpoint](https://comix.to/api/v1/chapters/11169424)
+
+The API client imports export `i` from the security bundle and calls it with the Axios instance. That export installs one request interceptor and one response interceptor. The request interceptor calls the internal `M2(url, params)` function and writes its result to `params._`. [API client bundle](https://comix.to/assets/build/35595e3de3c99889c1aa70/dist/env-tjdqki-WSjnHwGH.js) [Security bundle](https://comix.to/assets/build/35595e3de3c99889c1aa70/dist/secure-tjdqki-DZP4UvtB.js)
+
+## Token input
+
+The request interceptor only acts on `GET`. A missing method is treated as `GET`. `M2` then does this work:
+
+1. Remove an `http://` or `https://` origin from the URL.
+2. Remove the URL query at the first `?`.
+3. Remove a leading `/api/v1`.
+4. Continue only when the remaining path matches one of these expressions:
+   - `^/manga(?:/|$)`
+   - `^/chapters/[^/]+(?:\?|$)`
+   - `^/groups/[0-9]+/chapters(?:\?|$)`
+5. Recursively flatten the Axios `params` object.
+6. Append `?` and the flattened parameters when the result is not empty.
+
+Parameter canonicalization has these rules:
+
+- Sort object keys at every level.
+- Skip the `_` key.
+- Skip `null` and `undefined` values.
+- Write arrays in order with numeric bracket keys, such as `rating[0]=safe`.
+- Write nested objects with bracket keys, such as `order[number]=desc`.
+- Convert scalar values with JavaScript `String(value)`.
+- Do not URL-encode keys or values.
+- Join pairs with `&`.
+
+For example:
+
+```text
+URL:    /api/v1/manga/pvry/chapters
+params: {page: 1, limit: 20, order: {number: "desc"}}
+input:  /manga/pvry/chapters?limit=20&order[number]=desc&page=1
+```
+
+The route and query are therefore both bound to the token. The method, origin, cookies, and headers are not part of the encoded input. The module also checks that it runs on a Comix host before it installs the interceptors. That host check is only a browser-side installation guard. It is not an input to the token. [Security bundle](https://comix.to/assets/build/35595e3de3c99889c1aa70/dist/secure-tjdqki-DZP4UvtB.js)
+
+## Token algorithm
+
+Convert the canonical input to UTF-8. Pass the bytes through three chained substitution stages. Each stage uses this operation:
+
+```text
+previous = seed
+for i from 0 through len(input)-1:
+    output[i] = table[(input[i] XOR key[i mod len(key)] XOR previous) AND 255]
+    previous = output[i]
+```
+
+Use these stages in order:
+
+| Stage | Seed | Decoded table length | Decoded key length |
+| --- | ---: | ---: | ---: |
+| 1 | 189 | 256 | 24 |
+| 2 | 133 | 256 | 24 |
+| 3 | 32 | 256 | 32 |
+
+The current Base64-encoded tables and keys are below. Standard Base64-decode each value before use. [Security bundle](https://comix.to/assets/build/35595e3de3c99889c1aa70/dist/secure-tjdqki-DZP4UvtB.js)
+
+```text
+stage1.table = gbicCvAMzfcXEtGAyjvvhmb2yCWzWhjqcxXZ7ZhpzANOzoQLo3nuPZ2vK9dkb9hJExC0Vni/hdQBceI+mw611gkhQFjBuf4bJg1TxYqM+SL4YDqtwjxiGSdeH7so7Fn1HiRo37Z+RNvl44twXWVhomtMjw+8bemfmv9XEXr7mS82MxaCOJZRR0oHd9PLI5O+gyBGT6hcLoduNa7yCObVVCk3bFWsoD+xcqTrBcP6dNJN/NB1Br2QGhSN2snHAqeRNKVFQiyeAFLPSKGwY8aq9EPgsi17qd4ywPMxiH8w6N1qX1tLKtzhOeemHWeJQfFQ5H23q7qSlJUcjgTEl3x2/Q==
+stage1.key   = rafYl4oSAKQX+GYoic9oW4iGwiYpZzs0
+
+stage2.table = 2lQehmgyYFAoWUi0haazZqHy5zZ34NN+VzlfsoB2Y1yY0IuMLjgVcV2xt8t4moH+AP0NMJ5qekW7DFIHEWKkOgIBIMhDdA8lbM6iHKjDlq6IChpb3CnA9NmsvQW/afdt1SfJjTdwcvpKqunCJLxBFmXX9hecm6tGb+HRxD7BC3njoxPxgnX5pdKP1IMSkd4/O3NRfZSE6DVLG2s9uexaipA05cpJzE8Qkv/z5jzHAwlEWOLd3yxA+0cvVbpOoJPFGc8f1lb4vu2HUxjuuEwEQk0GsPCVnyKvfOoh9TG2YYmZLV4I67UU2NsrrakqZ47k/O+ne25/DjPGZCMdnZcmzQ==
+stage2.key   = 2USAq+VTo5ht4bQn+K9DUcpUQRTtrB56
+
+stage3.table = +mhJSFwzaV+PQPDyKp2scO/S9SdFsy/7e56UWT8XHbK3E2+19nEPwfwOgE9uVCaDtOAWTobCZX+cBCXlIbBqyDyQB1beKLspW6kGPhBCV9x0jf0KUeFhHjmlMf7qMFIB41PfDFprZ3bJiK4YxrZDv+K6dcwJmggVO8f5ktrXTM0cZL4fer0SpnkbvNajPbHxfuTz5lVEBarOI4rdc+2V6zTsjpfQYjgN1MMr6EvA6eehN6dQ1bgUogt9rZOBbQBeNnLYY00uZqSoJBnFi5gthCJsWF33ykosn9v/9KB8udMCz0YRYImrA4VHr5mMgpH4xDXLeEHRd5vZOiAalofuMg==
+stage3.key   = yNHlokVEnuecesDrB/lDhVuUNiheWc3a47VtkwZ2ENg=
+```
+
+Encode the final bytes as unpadded Base64url. The token length is therefore the unpadded Base64 length of the UTF-8 input. There is no MAC, nonce, timestamp, or random salt.
+
+The visible constant `n1PEbDBiipbJZvZc` belongs to other functions on the internal codec object. The request path calls codec method `D`, which uses the three stages above. That visible constant is not the request token key.
+
+## Reproduction results
+
+An independent implementation outside the page matched the bundle output exactly for:
+
+- `/manga/pvry`
+- `/manga/qqwrm`
+- `/chapters/11170876`
+- One Piece chapter-list pages 1 and 2
+- a title search request
+
+This current test vector is useful for regression checks:
+
+```text
+input = /manga/pvry/chapters?limit=20&order[number]=desc&page=1
+token = IZ-P1pUtAjt3Oig5K1xNJ4A3XDWhN5iWaB2v65-B44CevAKBEF0OAOg-407yPS4VFzRxRsBwdg
+```
+
+Direct requests with independently generated tokens returned `200` for search, chapter list, and chapter detail without browser cookies. The chapter-list and chapter-detail responses had `x-enc: 1`. In a separate binding check, reusing a valid `limit=2` token with `limit=3` returned `403` and `{"message":"Invalid token."}`. [Live chapter-list endpoint](https://comix.to/api/v1/manga/pvry/chapters?page=1&limit=2) [Live chapter endpoint](https://comix.to/api/v1/chapters/11169424)
+
+## Separate protection layers
+
+The request token, API response decryption, and image descrambling are separate operations.
+
+### Request token
+
+The request interceptor generates `_` before Axios sends an eligible `GET`. Its only data input is the normalized path plus canonical parameters. This operation is pure byte processing and is practical in Go.
+
+### API response decryption
+
+The response interceptor checks for `x-enc: 1` and an object body with an `e` string. It Base64url-decodes `e`, reverses stages 3, 2, and 1, UTF-8-decodes the bytes, and parses JSON. The inverse of one stage is:
+
+```text
+previous = seed
+for i from 0 through len(input)-1:
+    output[i] = inverseTable[input[i]] XOR key[i mod len(key)] XOR previous
+    previous = input[i]
+```
+
+After JSON parsing, the interceptor unwraps `{status: "ok", result: ...}` when present. A live two-item chapter-list response decrypted to an object with `items` and `meta`. This response codec uses the same hard-coded stage data, but it is not part of request token generation. [Security bundle](https://comix.to/assets/build/35595e3de3c99889c1aa70/dist/secure-tjdqki-DZP4UvtB.js)
+
+### Image descrambling
+
+The reader imports security export `t` separately. It calls this function only for page entries marked as scrambled. The function fetches the image with CORS, omitted credentials, and an abort signal. It reads `X-Scramble-Hash`, `X-Scramble-Seed`, `X-Scramble-Grid`, and `X-Scramble-Algo`, builds a tile order with embedded WebAssembly, and draws reordered tiles to a canvas. This path uses browser image and canvas APIs. It is unrelated to `_` and API response decryption. [Reader bundle](https://comix.to/assets/build/35595e3de3c99889c1aa70/dist/ReadPage-tjdqki-DcYDg-eV.js) [Security bundle](https://comix.to/assets/build/35595e3de3c99889c1aa70/dist/secure-tjdqki-DZP4UvtB.js)
+
+The embedded WebAssembly exports `buildOrderV1` and `buildOrderV2`. Version 1 uses a Fisher-Yates shuffle driven by the standard 32-bit LCG constants `1664525` and `1013904223`. Version 2 uses Fisher-Yates with xorshift32 shifts `13`, `17`, and `5`, with the seed forced odd. The current `X-Scramble-Algo: 3` selects version 2. The hash-prefix table contains `03632 -> 58414` and `02900 -> 117532`. The effective seed is the response seed XOR the matching prefix.
+
+The Go implementation reproduces the tile order and draws source tile `i` at destination tile `order[i]`. A live scrambled One Piece page reconstructed into a coherent page and passed a complete CLI archive smoke test.
+
+## Go feasibility and gaps
+
+Token generation, API response decryption, and image reconstruction can run in pure Go for this build. A browser and WebAssembly runtime are not required. An HTTP cookie jar was also not required by the tested logged-out API reads.
+
+Remaining risks and gaps:
+
+- The algorithm and all six values are private frontend implementation details. A build update can invalidate them without warning.
+- The server-side acceptance window for tokens from an older frontend build is unknown.
+- Mutation endpoints and signed-in endpoints were not tested.
+- Comix has no public API contract or compatibility promise for this behavior.

--- a/internal/domain/source.go
+++ b/internal/domain/source.go
@@ -2,6 +2,8 @@ package domain
 
 import (
 	"context"
+	"io"
+	"net/http"
 )
 
 type Source interface {
@@ -29,6 +31,13 @@ type Chapter struct {
 }
 
 type ImageInfo struct {
-	ImageURL      string
-	EncryptionKey string
+	ImageURL       string
+	EncryptionKey  string
+	RequestHeaders map[string]string
+	Processor      ImageProcessor
+}
+
+type ImageProcessor interface {
+	Extension() string
+	Process(http.Header, io.Reader, io.Writer) error
 }

--- a/internal/download/download.go
+++ b/internal/download/download.go
@@ -57,10 +57,11 @@ func Chapter(ctx context.Context, log zerolog.Logger, outputPath string, chapter
 				Str("image_url", truncateLink(img.ImageURL)).
 				Str("image_host", imageHost(img.ImageURL)).
 				Bool("encrypted", img.EncryptionKey != "").
+				Bool("processed", img.Processor != nil).
 				Str("tmp_name", filepath.Base(base)).
 				Logger()
 
-			return downloadImage(ctx, imageLog, img.ImageURL, img.EncryptionKey, base, imageIndex, len(chapter.ImageInfo))
+			return downloadImage(ctx, imageLog, img, base, imageIndex, len(chapter.ImageInfo))
 		})
 	}
 
@@ -75,25 +76,47 @@ func Chapter(ctx context.Context, log zerolog.Logger, outputPath string, chapter
 	return nil
 }
 
-// downloadImage fetches url, applies XOR–decrypt if xorKeyHex isn't empty, and stores the
-// file using the right extension that is inferred from the response headers or magic bytes.
-func downloadImage(ctx context.Context, log zerolog.Logger, imageURL, xorKeyHex, filenameNoExt string, imageIndex, imageTotal int) error {
+// downloadImage fetches an image, applies its required transform, and stores it with the right extension.
+func downloadImage(ctx context.Context, log zerolog.Logger, imageInfo domain.ImageInfo, filenameNoExt string, imageIndex, imageTotal int) error {
 	var (
 		filename string
 		key      []byte
 	)
 
-	if xorKeyHex != "" {
-		decodedKey, err := hex.DecodeString(xorKeyHex)
+	if imageInfo.EncryptionKey != "" {
+		decodedKey, err := hex.DecodeString(imageInfo.EncryptionKey)
 		if err != nil {
-			return wrapImageError(imageIndex, imageTotal, imageURL, fmt.Errorf("decoding encryption key: %w", err))
+			return wrapImageError(imageIndex, imageTotal, imageInfo.ImageURL, fmt.Errorf("decoding encryption key: %w", err))
 		}
 
 		key = decodedKey
 	}
 
-	if err := fetchWithRetry(ctx, log, imageURL, func(resp *http.Response) error {
+	if err := fetchWithRetry(ctx, log, imageInfo.ImageURL, imageInfo.RequestHeaders, func(resp *http.Response) error {
 		reader := bufio.NewReader(resp.Body)
+		var src io.Reader = reader
+		if len(key) > 0 {
+			src = &xorReader{
+				r:   reader,
+				key: key,
+			}
+		}
+
+		if imageInfo.Processor != nil {
+			filename = filenameNoExt + imageInfo.Processor.Extension()
+			out, err := os.Create(filename)
+			if err != nil {
+				return fmt.Errorf("creating file %s: %w", filename, err)
+			}
+			defer out.Close()
+
+			if err := imageInfo.Processor.Process(resp.Header, src, out); err != nil {
+				return retry.Unrecoverable(err)
+			}
+
+			return nil
+		}
+
 		contentType, err := detectContentType(resp, reader)
 		if err != nil {
 			return err
@@ -110,21 +133,13 @@ func downloadImage(ctx context.Context, log zerolog.Logger, imageURL, xorKeyHex,
 		}
 		defer out.Close()
 
-		var src io.Reader = reader
-		if len(key) > 0 {
-			src = &xorReader{
-				r:   reader,
-				key: key,
-			}
-		}
-
 		if _, err = io.Copy(out, src); err != nil {
 			return fmt.Errorf("writing file %s: %w", filename, err)
 		}
 
 		return nil
 	}); err != nil {
-		return wrapImageError(imageIndex, imageTotal, imageURL, err)
+		return wrapImageError(imageIndex, imageTotal, imageInfo.ImageURL, err)
 	}
 
 	return nil
@@ -168,12 +183,15 @@ func (r *xorReader) Read(p []byte) (int, error) {
 }
 
 // fetchWithRetry executes the GET request with a common retry strategy and passes the successful response to onSuccess.
-func fetchWithRetry(ctx context.Context, log zerolog.Logger, url string, onSuccess func(*http.Response) error) error {
+func fetchWithRetry(ctx context.Context, log zerolog.Logger, url string, headers map[string]string, onSuccess func(*http.Response) error) error {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return fmt.Errorf("creating request: %w", err)
 	}
 	req.Header.Set("User-Agent", userAgent)
+	for name, value := range headers {
+		req.Header.Set(name, value)
+	}
 
 	client := http.Client{
 		Timeout:   60 * time.Second,

--- a/internal/download/download_test.go
+++ b/internal/download/download_test.go
@@ -7,6 +7,7 @@ import (
 	"image"
 	"image/color"
 	"image/png"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -14,6 +15,7 @@ import (
 	"sync/atomic"
 	"testing"
 
+	"mangarr/internal/domain"
 	"mangarr/internal/sharedhttp"
 
 	"github.com/rs/zerolog"
@@ -31,7 +33,7 @@ func TestDownloadImageStreamsBodyToDisk(t *testing.T) {
 	defer server.Close()
 
 	outBase := filepath.Join(t.TempDir(), "img")
-	err := downloadImage(context.Background(), zerolog.Nop(), server.URL, "", outBase, 1, 1)
+	err := downloadImage(context.Background(), zerolog.Nop(), domain.ImageInfo{ImageURL: server.URL}, outBase, 1, 1)
 	require.NoError(t, err)
 
 	got, err := os.ReadFile(outBase + ".png")
@@ -53,7 +55,10 @@ func TestDownloadImageDecryptsWhileStreaming(t *testing.T) {
 	defer server.Close()
 
 	outBase := filepath.Join(t.TempDir(), "img")
-	err := downloadImage(context.Background(), zerolog.Nop(), server.URL, hex.EncodeToString(key), outBase, 1, 1)
+	err := downloadImage(context.Background(), zerolog.Nop(), domain.ImageInfo{
+		ImageURL:      server.URL,
+		EncryptionKey: hex.EncodeToString(key),
+	}, outBase, 1, 1)
 	require.NoError(t, err)
 
 	got, err := os.ReadFile(outBase + ".jpg")
@@ -76,11 +81,35 @@ func TestDownloadImageDetectsTypeFromMagicBytes(t *testing.T) {
 	defer server.Close()
 
 	outBase := filepath.Join(t.TempDir(), "img")
-	err := downloadImage(context.Background(), zerolog.Nop(), server.URL, "", outBase, 1, 1)
+	err := downloadImage(context.Background(), zerolog.Nop(), domain.ImageInfo{ImageURL: server.URL}, outBase, 1, 1)
 	require.NoError(t, err)
 
 	_, statErr := os.Stat(outBase + ".png")
 	require.NoError(t, statErr)
+}
+
+func TestDownloadImageAppliesHeadersAndProcessor(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-Image-Test") != "present" {
+			t.Errorf("missing image request header")
+		}
+		_, _ = w.Write([]byte("payload"))
+	}))
+	defer server.Close()
+
+	outBase := filepath.Join(t.TempDir(), "img")
+	err := downloadImage(t.Context(), zerolog.Nop(), domain.ImageInfo{
+		ImageURL:       server.URL,
+		RequestHeaders: map[string]string{"X-Image-Test": "present"},
+		Processor:      testImageProcessor{},
+	}, outBase, 1, 1)
+	require.NoError(t, err)
+
+	result, err := os.ReadFile(outBase + ".processed")
+	require.NoError(t, err)
+	require.Equal(t, []byte("processed:payload"), result)
 }
 
 func TestDownloadImageRetriesTransientServerError(t *testing.T) {
@@ -100,7 +129,7 @@ func TestDownloadImageRetriesTransientServerError(t *testing.T) {
 	defer server.Close()
 
 	outBase := filepath.Join(t.TempDir(), "img")
-	err := downloadImage(context.Background(), zerolog.Nop(), server.URL, "", outBase, 1, 1)
+	err := downloadImage(context.Background(), zerolog.Nop(), domain.ImageInfo{ImageURL: server.URL}, outBase, 1, 1)
 	require.NoError(t, err)
 
 	got, err := os.ReadFile(outBase + ".png")
@@ -120,7 +149,7 @@ func TestDownloadImageStopsAfterThreeAttemptsOnPermanentFailure(t *testing.T) {
 	defer server.Close()
 
 	outBase := filepath.Join(t.TempDir(), "img")
-	err := downloadImage(context.Background(), zerolog.Nop(), server.URL, "", outBase, 1, 1)
+	err := downloadImage(context.Background(), zerolog.Nop(), domain.ImageInfo{ImageURL: server.URL}, outBase, 1, 1)
 	require.Error(t, err)
 	require.Equal(t, int32(sharedhttp.RetryAttempts), attempts.Load())
 }
@@ -132,4 +161,19 @@ func xorBytes(data, key []byte) []byte {
 	}
 
 	return out
+}
+
+type testImageProcessor struct{}
+
+func (testImageProcessor) Extension() string {
+	return ".processed"
+}
+
+func (testImageProcessor) Process(_ http.Header, reader io.Reader, writer io.Writer) error {
+	if _, err := io.WriteString(writer, "processed:"); err != nil {
+		return err
+	}
+	_, err := io.Copy(writer, reader)
+
+	return err
 }

--- a/internal/source/comix.go
+++ b/internal/source/comix.go
@@ -1,12 +1,14 @@
 package source
 
 import (
-	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/http/cookiejar"
 	"net/url"
+	"reflect"
+	"strconv"
 	"strings"
 	"time"
 
@@ -20,133 +22,92 @@ import (
 const (
 	comixURL         = "https://comix.to"
 	comixResultLimit = 100
-
-	comixOfficialGroupID = "9275"
-	comixDeprecatedError = "Comix is deprecated because chapter pages now require a browser-generated token"
 )
 
 type comix struct {
 	MangaURL string
 	GroupID  string
+	BaseURL  string
 	Client   *http.Client
+	Codec    comixCodec
+	CodecErr error
 }
 
-type comixMangaResponse struct {
-	Status int `json:"status"`
-	Result struct {
-		MangaID   int      `json:"manga_id"`
-		HashID    string   `json:"hash_id"`
-		Title     string   `json:"title"`
-		AltTitles []string `json:"alt_titles"`
-		Synopsis  string   `json:"synopsis"`
-		Slug      string   `json:"slug"`
-		Rank      int      `json:"rank"`
-		Type      string   `json:"type"`
-		Poster    struct {
-			Small  string `json:"small"`
-			Medium string `json:"medium"`
-			Large  string `json:"large"`
-		} `json:"poster"`
-		OriginalLanguage string  `json:"original_language"`
-		Status           string  `json:"status"`
-		FinalVolume      int     `json:"final_volume"`
-		FinalChapter     int     `json:"final_chapter"`
-		HasChapters      bool    `json:"has_chapters"`
-		LatestChapter    int     `json:"latest_chapter"`
-		ChapterUpdatedAt int     `json:"chapter_updated_at"`
-		StartDate        int     `json:"start_date"`
-		EndDate          string  `json:"end_date"`
-		CreatedAt        int     `json:"created_at"`
-		UpdatedAt        int     `json:"updated_at"`
-		RatedAvg         float64 `json:"rated_avg"`
-		RatedCount       int     `json:"rated_count"`
-		FollowsTotal     int     `json:"follows_total"`
-		Links            struct {
-			Al  string `json:"al"`
-			Mal string `json:"mal"`
-			Mu  string `json:"mu"`
-		} `json:"links"`
-		IsNsfw  bool  `json:"is_nsfw"`
-		Year    int   `json:"year"`
-		TermIds []int `json:"term_ids"`
-	} `json:"result"`
+type comixManga struct {
+	ID    int    `json:"id"`
+	HID   string `json:"hid"`
+	Title string `json:"title"`
+	Type  string `json:"type"`
+	URL   string `json:"url"`
 }
 
-type comixChaptersResponse struct {
-	Status int `json:"status"`
-	Result struct {
-		Items      []comixChapter `json:"items"`
-		Pagination struct {
-			Count       int `json:"count"`
-			Total       int `json:"total"`
-			PerPage     int `json:"per_page"`
-			CurrentPage int `json:"current_page"`
-			LastPage    int `json:"last_page"`
-			From        int `json:"from"`
-			To          int `json:"to"`
-		} `json:"pagination"`
-	} `json:"result"`
-}
-
-type comixChapterResponse struct {
-	Status int `json:"status"`
-	Result struct {
-		ChapterID         int                  `json:"chapter_id"`
-		MangaID           int                  `json:"manga_id"`
-		ScanlationGroupID int                  `json:"scanlation_group_id"`
-		Number            domain.ChapterNumber `json:"number"`
-		Name              string               `json:"name"`
-		Language          string               `json:"language"`
-		Volume            int                  `json:"volume"`
-		Votes             int                  `json:"votes"`
-		CreatedAt         int                  `json:"created_at"`
-		UpdatedAt         int                  `json:"updated_at"`
-		ScanlationGroup   struct {
-			ScanlationGroupID int    `json:"scanlation_group_id"`
-			Name              string `json:"name"`
-			Slug              string `json:"slug"`
-		} `json:"scanlation_group"`
-		Images []comixImage `json:"images"`
-		Prev   comixChapter `json:"prev"`
-		Next   comixChapter `json:"next"`
-	} `json:"result"`
+type comixChapterList struct {
+	Items []comixChapter `json:"items"`
+	Meta  struct {
+		Page     int `json:"page"`
+		LastPage int `json:"lastPage"`
+	} `json:"meta"`
 }
 
 type comixChapter struct {
-	ChapterID         int                  `json:"chapter_id"`
-	MangaID           int                  `json:"manga_id"`
-	ScanlationGroupID int                  `json:"scanlation_group_id"`
-	Number            domain.ChapterNumber `json:"number"`
-	Name              string               `json:"name"`
-	Language          string               `json:"language"`
-	Volume            int                  `json:"volume"`
-	Votes             int                  `json:"votes"`
-	CreatedAt         int                  `json:"created_at"`
-	UpdatedAt         int                  `json:"updated_at"`
-	ScanlationGroup   struct {
-		ScanlationGroupID int    `json:"scanlation_group_id"`
-		Name              string `json:"name"`
-		Slug              string `json:"slug"`
-	} `json:"scanlation_group"`
-	Images []comixImage `json:"images"`
+	ID      int                  `json:"id"`
+	MangaID int                  `json:"mangaId"`
+	Number  domain.ChapterNumber `json:"number"`
+	Name    string               `json:"name"`
+	GroupID int                  `json:"groupId"`
+	URL     string               `json:"url"`
 }
 
-type comixImage struct {
-	Width  int    `json:"width"`
-	Height int    `json:"height"`
-	URL    string `json:"url"`
+type comixChapterDetail struct {
+	comixChapter
+	Pages comixPages `json:"pages"`
+}
+
+type comixPages struct {
+	BaseURL string      `json:"baseUrl"`
+	Items   []comixPage `json:"items"`
+}
+
+type comixPage struct {
+	Width     int    `json:"width"`
+	Height    int    `json:"height"`
+	URL       string `json:"url"`
+	Scrambled int    `json:"s"`
+}
+
+func (p *comixPages) UnmarshalJSON(data []byte) error {
+	var direct []comixPage
+	if err := json.Unmarshal(data, &direct); err == nil {
+		p.Items = direct
+		return nil
+	}
+
+	type pagesAlias comixPages
+	var compact pagesAlias
+	if err := json.Unmarshal(data, &compact); err != nil {
+		return fmt.Errorf("decoding Comix pages: %w", err)
+	}
+	*p = comixPages(compact)
+
+	return nil
 }
 
 func NewComix(mangaURL, groupID string) domain.Source {
+	jar, _ := cookiejar.New(nil)
+	codec, codecErr := newComixCodec()
 	client := http.Client{
 		Timeout:   60 * time.Second,
 		Transport: sharedhttp.Transport,
+		Jar:       jar,
 	}
 
 	return &comix{
 		MangaURL: mangaURL,
 		GroupID:  groupID,
+		BaseURL:  comixURL,
 		Client:   &client,
+		Codec:    codec,
+		CodecErr: codecErr,
 	}
 }
 
@@ -155,233 +116,233 @@ func (c *comix) String() string {
 }
 
 func (c *comix) ValidateInput() error {
-	return fmt.Errorf(comixDeprecatedError)
+	if _, err := c.extractIDFromURL(c.MangaURL); err != nil {
+		return err
+	}
+	if c.GroupID != "" {
+		if _, err := strconv.ParseUint(c.GroupID, 10, 64); err != nil {
+			return fmt.Errorf("Comix group ID must be numeric: %w", err)
+		}
+	}
+
+	return nil
 }
 
 func (c *comix) GetManga(ctx context.Context) (domain.Manga, error) {
-	var (
-		mangaResp comixMangaResponse
-		manga     domain.Manga
-	)
-
 	mangaID, err := c.extractIDFromURL(c.MangaURL)
 	if err != nil {
-		return domain.Manga{}, fmt.Errorf("extracting ID from URL %s: %w", c.MangaURL, err)
+		return domain.Manga{}, fmt.Errorf("extracting Comix ID from URL %s: %w", c.MangaURL, err)
 	}
 
-	path, err := url.JoinPath(comixURL, "api/v2/manga/", mangaID)
-	if err != nil {
-		return domain.Manga{}, fmt.Errorf("building URL: %w", err)
+	var response comixManga
+	if err := c.get(ctx, comixAPIPath+"/manga/"+url.PathEscape(mangaID), nil, &response); err != nil {
+		return domain.Manga{}, fmt.Errorf("getting Comix manga %s: %w", mangaID, err)
+	}
+	if response.HID == "" || response.Title == "" {
+		return domain.Manga{}, fmt.Errorf("getting Comix manga %s: response is missing hid or title", mangaID)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, path, nil)
-	if err != nil {
-		return domain.Manga{}, fmt.Errorf("creating request: %w", err)
-	}
-
-	req.Header.Set("User-Agent", "mangarr")
-
-	retryErr := retry.Do(func() error {
-		resp, err := sharedhttp.ExecRequest(*c.Client, req)
-		if err != nil {
-			return err
-		}
-		defer resp.Body.Close()
-
-		buf := bufio.NewReader(resp.Body)
-
-		err = json.NewDecoder(buf).Decode(&mangaResp)
-		if err != nil {
-			return retry.Unrecoverable(fmt.Errorf("decoding response: %w", err))
-		}
-
-		return nil
-	},
-		sharedhttp.RetryOptions(ctx)...,
-	)
-	if retryErr != nil {
-		return domain.Manga{}, fmt.Errorf("executing request %s: %w", req.URL, retryErr)
-	}
-
-	if mangaResp.Status != http.StatusOK {
-		return domain.Manga{}, fmt.Errorf("unexpected status code: %d", mangaResp.Status)
-	}
-
-	manga = domain.Manga{
-		ID:       mangaID,
-		Title:    sanitize.Filename(mangaResp.Result.Title),
+	return domain.Manga{
+		ID:       response.HID,
+		URL:      resolveComixURL(c.BaseURL, response.URL),
+		Title:    sanitize.Filename(response.Title),
 		Chapters: make(map[domain.ChapterNumber]domain.Chapter),
-	}
-
-	return manga, nil
+		IsManhwa: response.Type == "manhwa" || response.Type == "manhua",
+	}, nil
 }
 
 func (c *comix) GetChapters(ctx context.Context, manga domain.Manga) error {
-	var (
-		retryErr    error
-		chapterResp comixChaptersResponse
-
-		page = 1
-	)
-
-	path, err := url.JoinPath(comixURL, "api/v2/manga", manga.ID, "chapters")
-	if err != nil {
-		return fmt.Errorf("building URL: %w", err)
+	if manga.ID == "" {
+		return fmt.Errorf("getting Comix chapters: manga ID is empty")
+	}
+	if manga.Chapters == nil {
+		return fmt.Errorf("getting Comix chapters for manga %s: chapter map is nil", manga.ID)
 	}
 
-	u, err := url.Parse(path)
-	if err != nil {
-		return fmt.Errorf("parsing URL %s: %w", path, err)
+	processed := make(map[domain.ChapterNumber]struct{})
+	for page := 1; ; page++ {
+		params := comixParams{
+			"limit": comixResultLimit,
+			"order": map[string]any{"number": "desc"},
+			"page":  page,
+		}
+		if c.GroupID != "" {
+			params["group_id"] = c.GroupID
+		}
+
+		var response comixChapterList
+		path := comixAPIPath + "/manga/" + url.PathEscape(manga.ID) + "/chapters"
+		if err := c.get(ctx, path, params, &response); err != nil {
+			return fmt.Errorf("getting Comix chapters for manga %s page %d: %w", manga.ID, page, err)
+		}
+
+		for _, item := range response.Items {
+			if !c.shouldProcessChapter(item, c.GroupID) {
+				continue
+			}
+			if _, exists := processed[item.Number]; exists {
+				continue
+			}
+
+			manga.Chapters[item.Number] = domain.Chapter{
+				ID:     strconv.Itoa(item.ID),
+				URL:    resolveComixURL(c.BaseURL, item.URL),
+				Number: item.Number,
+				Title:  sanitize.Filename(item.Name),
+			}
+			processed[item.Number] = struct{}{}
+		}
+
+		if response.Meta.LastPage <= page {
+			break
+		}
 	}
 
-	processedChapters := make(map[domain.ChapterNumber]bool)
-
-	for {
-		params := url.Values{
-			"order[number]":       []string{"desc"},
-			"limit":               []string{fmt.Sprintf("%d", comixResultLimit)},
-			"page":                []string{fmt.Sprintf("%d", page)},
-			"scanlation_group_id": []string{c.GroupID},
-		}
-
-		u.RawQuery = params.Encode()
-
-		req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
-		if err != nil {
-			return fmt.Errorf("creating request: %w", err)
-		}
-
-		req.Header.Set("User-Agent", "mangarr")
-
-		retryErr = retry.Do(func() error {
-			resp, err := sharedhttp.ExecRequest(*c.Client, req)
-			if err != nil {
-				return err
-			}
-			defer resp.Body.Close()
-
-			buf := bufio.NewReader(resp.Body)
-
-			err = json.NewDecoder(buf).Decode(&chapterResp)
-			if err != nil {
-				return retry.Unrecoverable(fmt.Errorf("decoding response: %w", err))
-			}
-
-			return nil
-		},
-			sharedhttp.RetryOptions(ctx)...,
-		)
-		if retryErr != nil {
-			return fmt.Errorf("executing request %s: %w", req.URL, retryErr)
-		}
-
-		for _, item := range chapterResp.Result.Items {
-			if c.shouldProcessChapter(item, c.GroupID) {
-				if processedChapters[item.Number] {
-					continue
-				}
-
-				manga.Chapters[item.Number] = domain.Chapter{
-					ID:     fmt.Sprintf("%d", item.ChapterID),
-					Number: item.Number,
-					Title:  sanitize.Filename(item.Name),
-				}
-
-				processedChapters[item.Number] = true
-			}
-		}
-
-		if len(manga.Chapters) == 0 {
-			return fmt.Errorf("getting chapters for manga ID %s", c.MangaURL)
-		}
-
-		if page == chapterResp.Result.Pagination.LastPage {
-			return nil
-		}
-
-		page += 1
+	if len(manga.Chapters) == 0 {
+		return fmt.Errorf("getting Comix chapters for manga %s: response has no matching chapters", manga.ID)
 	}
+
+	return nil
 }
 
 func (c *comix) GetImageURLs(ctx context.Context, chapter *domain.Chapter) error {
-	var chapterResp comixChapterResponse
-	var imageInfos []domain.ImageInfo
-
-	path, err := url.JoinPath(comixURL, "api/v2/chapters/", chapter.ID)
-	if err != nil {
-		return fmt.Errorf("building URL: %w", err)
+	if chapter == nil || chapter.ID == "" {
+		return fmt.Errorf("getting Comix image URLs: chapter ID is empty")
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, path, nil)
-	if err != nil {
-		return fmt.Errorf("creating request: %w", err)
+	var response comixChapterDetail
+	if err := c.get(ctx, comixAPIPath+"/chapters/"+url.PathEscape(chapter.ID), nil, &response); err != nil {
+		return fmt.Errorf("getting Comix image URLs for chapter %s: %w", chapter.ID, err)
+	}
+	if len(response.Pages.Items) == 0 {
+		return fmt.Errorf("getting Comix image URLs for chapter %s: response has no pages", chapter.ID)
 	}
 
-	req.Header.Set("User-Agent", "mangarr")
-
-	retryErr := retry.Do(func() error {
-		resp, err := sharedhttp.ExecRequest(*c.Client, req)
-		if err != nil {
-			return err
+	imageInfos := make([]domain.ImageInfo, 0, len(response.Pages.Items))
+	for i, image := range response.Pages.Items {
+		imageURL := resolveComixURL(response.Pages.BaseURL, image.URL)
+		if imageURL == "" {
+			return fmt.Errorf("getting Comix image URLs for chapter %s: page %d URL is empty", chapter.ID, i+1)
 		}
-		defer resp.Body.Close()
-
-		buf := bufio.NewReader(resp.Body)
-
-		err = json.NewDecoder(buf).Decode(&chapterResp)
-		if err != nil {
-			return retry.Unrecoverable(fmt.Errorf("decoding response: %w", err))
+		imageInfo := domain.ImageInfo{
+			ImageURL: imageURL,
+			RequestHeaders: map[string]string{
+				"Referer": resolveComixURL(c.BaseURL, "/"),
+			},
 		}
-
-		return nil
-	},
-		sharedhttp.RetryOptions(ctx)...,
-	)
-	if retryErr != nil {
-		return fmt.Errorf("executing request %s: %w", req.URL, retryErr)
-	}
-
-	for _, image := range chapterResp.Result.Images {
-		imageInfos = append(imageInfos, domain.ImageInfo{ImageURL: image.URL})
-	}
-
-	if len(imageInfos) == 0 {
-		return fmt.Errorf("getting image URLs for chapter ID %s", chapter.ID)
+		if image.Scrambled != 0 {
+			imageInfo.Processor = comixImageProcessor{}
+		}
+		imageInfos = append(imageInfos, imageInfo)
 	}
 
 	chapter.ImageInfo = imageInfos
 	return nil
 }
 
-func (c *comix) shouldProcessChapter(data comixChapter, groupID string) bool {
-	if len(groupID) == 0 {
-		return true
+func (c *comix) get(ctx context.Context, path string, params comixParams, destination any) error {
+	if c.CodecErr != nil {
+		return fmt.Errorf("loading Comix frontend build %s codec: %w", comixFrontendBuild, c.CodecErr)
 	}
 
-	if fmt.Sprintf("%d", data.ScanlationGroupID) == groupID {
-		return true
+	requestURL, err := url.JoinPath(c.BaseURL, path)
+	if err != nil {
+		return fmt.Errorf("building Comix request URL: %w", err)
 	}
+	token, err := c.Codec.token(requestURL, params)
+	if err != nil {
+		return fmt.Errorf("generating Comix request token: %w", err)
+	}
+	query, err := comixQuery(params)
+	if err != nil {
+		return err
+	}
+	query.Set(comixTokenParameter, token)
 
-	return false
+	parsed, err := url.Parse(requestURL)
+	if err != nil {
+		return fmt.Errorf("parsing Comix request URL: %w", err)
+	}
+	parsed.RawQuery = query.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, parsed.String(), nil)
+	if err != nil {
+		return fmt.Errorf("creating Comix request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", "mangarr")
+	req.Header.Set("X-Requested-With", "XMLHttpRequest")
+
+	return retry.Do(func() error {
+		resp, err := sharedhttp.ExecRequest(*c.Client, req)
+		if err != nil {
+			return err
+		}
+		defer resp.Body.Close()
+
+		encrypted := resp.Header.Get(comixResponseEncryptionHeader) == comixResponseEncryptionEnabled
+		if err := c.Codec.decodeResponse(resp.Body, encrypted, destination); err != nil {
+			return retry.Unrecoverable(err)
+		}
+
+		return nil
+	}, sharedhttp.RetryOptions(ctx)...)
 }
 
-func (c *comix) extractIDFromURL(urlStr string) (string, error) {
-	u, err := url.Parse(urlStr)
+func comixQuery(params comixParams) (url.Values, error) {
+	pairs := make([]string, 0, len(params))
+	if err := flattenComixParams(&pairs, "", reflect.ValueOf(map[string]any(params))); err != nil {
+		return nil, fmt.Errorf("encoding Comix query: %w", err)
+	}
+
+	values := make(url.Values, len(pairs))
+	for _, pair := range pairs {
+		key, value, _ := strings.Cut(pair, "=")
+		values.Add(key, value)
+	}
+
+	return values, nil
+}
+
+func (c *comix) shouldProcessChapter(data comixChapter, groupID string) bool {
+	return groupID == "" || strconv.Itoa(data.GroupID) == groupID
+}
+
+func (c *comix) extractIDFromURL(rawURL string) (string, error) {
+	parsed, err := url.Parse(rawURL)
 	if err != nil {
 		return "", fmt.Errorf("parsing URL: %w", err)
 	}
-
-	path := strings.Trim(u.Path, "/")
-	parts := strings.Split(path, "/")
-
-	if len(parts) < 2 || parts[0] != "title" {
-		return "", fmt.Errorf("invalid URL format")
+	if parsed.Scheme != "https" || parsed.Host != "comix.to" {
+		return "", fmt.Errorf("URL must use https://comix.to")
 	}
 
-	slug := parts[1]
-	if before, _, ok := strings.Cut(slug, "-"); ok {
-		return before, nil
+	parts := strings.Split(strings.Trim(parsed.Path, "/"), "/")
+	if len(parts) != 2 || parts[0] != "title" || parts[1] == "" {
+		return "", fmt.Errorf("URL must match https://comix.to/title/{id}-{slug}")
+	}
+	if mangaID, _, found := strings.Cut(parts[1], "-"); found && mangaID != "" {
+		return mangaID, nil
 	}
 
-	return slug, nil
+	return parts[1], nil
+}
+
+func resolveComixURL(baseURL, reference string) string {
+	if reference == "" {
+		return ""
+	}
+	parsedReference, err := url.Parse(reference)
+	if err != nil {
+		return ""
+	}
+	if parsedReference.IsAbs() {
+		return parsedReference.String()
+	}
+	parsedBase, err := url.Parse(baseURL)
+	if err != nil {
+		return ""
+	}
+
+	return parsedBase.ResolveReference(parsedReference).String()
 }

--- a/internal/source/comix_image.go
+++ b/internal/source/comix_image.go
@@ -1,0 +1,146 @@
+package source
+
+import (
+	"fmt"
+	"image"
+	"image/draw"
+	"image/png"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+
+	_ "golang.org/x/image/webp"
+)
+
+const (
+	comixScrambleAlgorithmV1A = "1"
+	comixScrambleAlgorithmV1B = "2"
+	comixScrambleAlgorithmV2  = "3"
+
+	comixLCGMultiplier uint32 = 1664525
+	comixLCGIncrement  uint32 = 1013904223
+
+	comixXorShiftLeftA = 13
+	comixXorShiftRight = 17
+	comixXorShiftLeftB = 5
+)
+
+// These values and shuffle versions match frontend build comixFrontendBuild.
+var comixScrambleHashPrefixes = map[string]uint32{
+	"03632": 58414,
+	"02900": 117532,
+}
+
+type comixImageProcessor struct{}
+
+func (comixImageProcessor) Extension() string {
+	return ".png"
+}
+
+func (comixImageProcessor) Process(headers http.Header, reader io.Reader, writer io.Writer) error {
+	source, _, err := image.Decode(reader)
+	if err != nil {
+		return fmt.Errorf("decoding scrambled Comix image: %w", err)
+	}
+
+	result, err := descrambleComixImage(source, headers)
+	if err != nil {
+		return err
+	}
+	if err := png.Encode(writer, result); err != nil {
+		return fmt.Errorf("encoding descrambled Comix image: %w", err)
+	}
+
+	return nil
+}
+
+func descrambleComixImage(source image.Image, headers http.Header) (image.Image, error) {
+	hash := strings.ToLower(headers.Get("X-Scramble-Hash"))
+	prefix, ok := comixScrambleHashPrefixes[hash]
+	if !ok {
+		return nil, fmt.Errorf("descrambling Comix image: unsupported hash %q", hash)
+	}
+
+	seedValue := headers.Get("X-Scramble-Seed")
+	seed, err := strconv.ParseUint(seedValue, 10, 32)
+	if err != nil {
+		return nil, fmt.Errorf("descrambling Comix image: invalid seed %q: %w", seedValue, err)
+	}
+	columns, rows, err := parseComixScrambleGrid(headers.Get("X-Scramble-Grid"))
+	if err != nil {
+		return nil, err
+	}
+
+	algorithm := headers.Get("X-Scramble-Algo")
+	if algorithm != comixScrambleAlgorithmV1A &&
+		algorithm != comixScrambleAlgorithmV1B &&
+		algorithm != comixScrambleAlgorithmV2 {
+		return nil, fmt.Errorf("descrambling Comix image: unsupported algorithm %q", algorithm)
+	}
+
+	bounds := source.Bounds()
+	width := bounds.Dx()
+	height := bounds.Dy()
+	tileWidth := width / columns
+	tileHeight := height / rows
+	if tileWidth < 1 || tileHeight < 1 {
+		return nil, fmt.Errorf("descrambling Comix image: grid %dx%d exceeds image size %dx%d", columns, rows, width, height)
+	}
+
+	order := buildComixScrambleOrder(uint32(seed)^prefix, columns*rows, algorithm == comixScrambleAlgorithmV2)
+	result := image.NewNRGBA(image.Rect(0, 0, width, height))
+	for sourceIndex, destinationIndex := range order {
+		sourceX := sourceIndex % columns * tileWidth
+		sourceY := sourceIndex / columns * tileHeight
+		destinationX := destinationIndex % columns * tileWidth
+		destinationY := destinationIndex / columns * tileHeight
+		destination := image.Rect(destinationX, destinationY, destinationX+tileWidth, destinationY+tileHeight)
+		draw.Draw(result, destination, source, image.Pt(bounds.Min.X+sourceX, bounds.Min.Y+sourceY), draw.Src)
+	}
+
+	return result, nil
+}
+
+func parseComixScrambleGrid(value string) (int, int, error) {
+	parts := strings.Split(value, "x")
+	if len(parts) != 2 {
+		return 0, 0, fmt.Errorf("descrambling Comix image: invalid grid %q", value)
+	}
+
+	columns, err := strconv.Atoi(parts[0])
+	if err != nil || columns < 1 {
+		return 0, 0, fmt.Errorf("descrambling Comix image: invalid grid %q", value)
+	}
+	rows, err := strconv.Atoi(parts[1])
+	if err != nil || rows < 1 {
+		return 0, 0, fmt.Errorf("descrambling Comix image: invalid grid %q", value)
+	}
+
+	return columns, rows, nil
+}
+
+func buildComixScrambleOrder(seed uint32, count int, versionTwo bool) []int {
+	order := make([]int, count)
+	for i := range order {
+		order[i] = i
+	}
+
+	state := seed
+	if versionTwo {
+		state |= 1
+	}
+	for i := count; i >= 2; i-- {
+		if versionTwo {
+			state ^= state << comixXorShiftLeftA
+			state ^= state >> comixXorShiftRight
+			state ^= state << comixXorShiftLeftB
+		} else {
+			state = state*comixLCGMultiplier + comixLCGIncrement
+		}
+		other := int(state % uint32(i))
+		order[i-1], order[other] = order[other], order[i-1]
+	}
+
+	return order
+}

--- a/internal/source/comix_image_test.go
+++ b/internal/source/comix_image_test.go
@@ -1,0 +1,93 @@
+package source
+
+import (
+	"bytes"
+	"image"
+	"image/color"
+	"image/draw"
+	"image/png"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildComixScrambleOrderMatchesFrontendAlgorithms(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t,
+		[]int{1, 3, 22, 5, 6, 12, 18, 11, 13, 15, 17, 14, 7, 0, 20, 10, 21, 16, 8, 24, 19, 4, 9, 2, 23},
+		buildComixScrambleOrder(0, 25, false),
+	)
+	require.Equal(t,
+		[]int{8, 11, 1, 24, 4, 14, 6, 5, 13, 10, 19, 20, 3, 7, 12, 23, 0, 21, 9, 16, 18, 17, 22, 15, 2},
+		buildComixScrambleOrder(4237225555, 25, true),
+	)
+}
+
+func TestComixImageProcessorDescramblesTiles(t *testing.T) {
+	t.Parallel()
+
+	original := image.NewNRGBA(image.Rect(0, 0, 4, 4))
+	colors := []color.NRGBA{
+		{R: 255, A: 255},
+		{G: 255, A: 255},
+		{B: 255, A: 255},
+		{R: 255, G: 255, A: 255},
+	}
+	for tile, tileColor := range colors {
+		x := tile % 2 * 2
+		y := tile / 2 * 2
+		draw.Draw(original, image.Rect(x, y, x+2, y+2), &image.Uniform{C: tileColor}, image.Point{}, draw.Src)
+	}
+
+	seed := uint32(100)
+	order := buildComixScrambleOrder(seed^comixScrambleHashPrefixes["03632"], 4, true)
+	scrambled := image.NewNRGBA(original.Bounds())
+	for sourceIndex, destinationIndex := range order {
+		sourceX := sourceIndex % 2 * 2
+		sourceY := sourceIndex / 2 * 2
+		destinationX := destinationIndex % 2 * 2
+		destinationY := destinationIndex / 2 * 2
+		draw.Draw(
+			scrambled,
+			image.Rect(sourceX, sourceY, sourceX+2, sourceY+2),
+			original,
+			image.Pt(destinationX, destinationY),
+			draw.Src,
+		)
+	}
+
+	var input bytes.Buffer
+	require.NoError(t, png.Encode(&input, scrambled))
+	var output bytes.Buffer
+	processor := comixImageProcessor{}
+	require.Equal(t, ".png", processor.Extension())
+	require.NoError(t, processor.Process(http.Header{
+		"X-Scramble-Hash": []string{"03632"},
+		"X-Scramble-Seed": []string{"100"},
+		"X-Scramble-Grid": []string{"2x2"},
+		"X-Scramble-Algo": []string{"3"},
+	}, &input, &output))
+
+	result, err := png.Decode(&output)
+	require.NoError(t, err)
+	require.Equal(t, original.Bounds(), result.Bounds())
+	for y := range original.Bounds().Dy() {
+		for x := range original.Bounds().Dx() {
+			require.Equal(t, original.NRGBAAt(x, y), color.NRGBAModel.Convert(result.At(x, y)))
+		}
+	}
+}
+
+func TestDescrambleComixImageRejectsUnknownHash(t *testing.T) {
+	t.Parallel()
+
+	_, err := descrambleComixImage(image.NewNRGBA(image.Rect(0, 0, 10, 10)), http.Header{
+		"X-Scramble-Hash": []string{"unknown"},
+		"X-Scramble-Seed": []string{"100"},
+		"X-Scramble-Grid": []string{"2x2"},
+		"X-Scramble-Algo": []string{"3"},
+	})
+	require.EqualError(t, err, `descrambling Comix image: unsupported hash "unknown"`)
+}

--- a/internal/source/comix_protocol.go
+++ b/internal/source/comix_protocol.go
@@ -1,0 +1,285 @@
+package source
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/url"
+	"reflect"
+	"sort"
+	"strconv"
+	"strings"
+	"unicode/utf8"
+)
+
+// comixFrontendBuild identifies the frontend bundle that defines the codec profile below.
+const comixFrontendBuild = "35595e3de3c99889c1aa70"
+
+const (
+	comixAPIPath                   = "/api/v1"
+	comixTokenParameter            = "_"
+	comixResponseEncryptionHeader  = "x-enc"
+	comixResponseEncryptionEnabled = "1"
+	comixCodecAlphabetSize         = 1 << 8
+
+	comixStage1Table = "gbicCvAMzfcXEtGAyjvvhmb2yCWzWhjqcxXZ7ZhpzANOzoQLo3nuPZ2vK9dkb9hJExC0Vni/hdQBceI+mw611gkhQFjBuf4bJg1TxYqM+SL4YDqtwjxiGSdeH7so7Fn1HiRo37Z+RNvl44twXWVhomtMjw+8bemfmv9XEXr7mS82MxaCOJZRR0oHd9PLI5O+gyBGT6hcLoduNa7yCObVVCk3bFWsoD+xcqTrBcP6dNJN/NB1Br2QGhSN2snHAqeRNKVFQiyeAFLPSKGwY8aq9EPgsi17qd4ywPMxiH8w6N1qX1tLKtzhOeemHWeJQfFQ5H23q7qSlJUcjgTEl3x2/Q=="
+	comixStage1Key   = "rafYl4oSAKQX+GYoic9oW4iGwiYpZzs0"
+	comixStage1Seed  = 189
+	comixStage2Table = "2lQehmgyYFAoWUi0haazZqHy5zZ34NN+VzlfsoB2Y1yY0IuMLjgVcV2xt8t4moH+AP0NMJ5qekW7DFIHEWKkOgIBIMhDdA8lbM6iHKjDlq6IChpb3CnA9NmsvQW/afdt1SfJjTdwcvpKqunCJLxBFmXX9hecm6tGb+HRxD7BC3njoxPxgnX5pdKP1IMSkd4/O3NRfZSE6DVLG2s9uexaipA05cpJzE8Qkv/z5jzHAwlEWOLd3yxA+0cvVbpOoJPFGc8f1lb4vu2HUxjuuEwEQk0GsPCVnyKvfOoh9TG2YYmZLV4I67UU2NsrrakqZ47k/O+ne25/DjPGZCMdnZcmzQ=="
+	comixStage2Key   = "2USAq+VTo5ht4bQn+K9DUcpUQRTtrB56"
+	comixStage2Seed  = 133
+	comixStage3Table = "+mhJSFwzaV+PQPDyKp2scO/S9SdFsy/7e56UWT8XHbK3E2+19nEPwfwOgE9uVCaDtOAWTobCZX+cBCXlIbBqyDyQB1beKLspW6kGPhBCV9x0jf0KUeFhHjmlMf7qMFIB41PfDFprZ3bJiK4YxrZDv+K6dcwJmggVO8f5ktrXTM0cZL4fer0SpnkbvNajPbHxfuTz5lVEBarOI4rdc+2V6zTsjpfQYjgN1MMr6EvA6eehN6dQ1bgUogt9rZOBbQBeNnLYY00uZqSoJBnFi5gthCJsWF33ykosn9v/9KB8udMCz0YRYImrA4VHr5mMgpH4xDXLeEHRd5vZOiAalofuMg=="
+	comixStage3Key   = "yNHlokVEnuecesDrB/lDhVuUNiheWc3a47VtkwZ2ENg="
+	comixStage3Seed  = 32
+)
+
+type comixParams map[string]any
+
+type comixCodecStage struct {
+	table   []byte
+	inverse [comixCodecAlphabetSize]byte
+	key     []byte
+	seed    byte
+}
+
+type comixCodec struct {
+	stages []comixCodecStage
+}
+
+func newComixCodec() (comixCodec, error) {
+	definitions := []struct {
+		table string
+		key   string
+		seed  byte
+	}{
+		{table: comixStage1Table, key: comixStage1Key, seed: comixStage1Seed},
+		{table: comixStage2Table, key: comixStage2Key, seed: comixStage2Seed},
+		{table: comixStage3Table, key: comixStage3Key, seed: comixStage3Seed},
+	}
+
+	codec := comixCodec{stages: make([]comixCodecStage, 0, len(definitions))}
+	for i, definition := range definitions {
+		table, err := base64.StdEncoding.DecodeString(definition.table)
+		if err != nil {
+			return comixCodec{}, fmt.Errorf("decoding Comix stage %d table: %w", i+1, err)
+		}
+		if len(table) != comixCodecAlphabetSize {
+			return comixCodec{}, fmt.Errorf("Comix stage %d table has length %d, want %d", i+1, len(table), comixCodecAlphabetSize)
+		}
+
+		key, err := base64.StdEncoding.DecodeString(definition.key)
+		if err != nil {
+			return comixCodec{}, fmt.Errorf("decoding Comix stage %d key: %w", i+1, err)
+		}
+		if len(key) == 0 {
+			return comixCodec{}, fmt.Errorf("Comix stage %d key is empty", i+1)
+		}
+
+		stage := comixCodecStage{table: table, key: key, seed: definition.seed}
+		var seen [256]bool
+		for input, output := range table {
+			if seen[output] {
+				return comixCodec{}, fmt.Errorf("Comix stage %d table is not a permutation", i+1)
+			}
+			seen[output] = true
+			stage.inverse[output] = byte(input)
+		}
+		codec.stages = append(codec.stages, stage)
+	}
+
+	return codec, nil
+}
+
+func (c comixCodec) token(rawURL string, params comixParams) (string, error) {
+	input, err := canonicalComixRequest(rawURL, params)
+	if err != nil {
+		return "", err
+	}
+
+	encoded := []byte(input)
+	for _, stage := range c.stages {
+		encoded = stage.encode(encoded)
+	}
+
+	return base64.RawURLEncoding.EncodeToString(encoded), nil
+}
+
+func (c comixCodec) decodeResponse(reader io.Reader, encrypted bool, destination any) error {
+	body, err := io.ReadAll(reader)
+	if err != nil {
+		return fmt.Errorf("reading Comix response: %w", err)
+	}
+
+	if encrypted {
+		var envelope struct {
+			Encoded string `json:"e"`
+		}
+		if err := json.Unmarshal(body, &envelope); err != nil {
+			return fmt.Errorf("decoding Comix encrypted envelope: %w", err)
+		}
+		if envelope.Encoded == "" {
+			return fmt.Errorf("decoding Comix encrypted envelope: missing e field")
+		}
+
+		body, err = base64.RawURLEncoding.DecodeString(envelope.Encoded)
+		if err != nil {
+			return fmt.Errorf("decoding Comix encrypted payload: %w", err)
+		}
+		for i := len(c.stages) - 1; i >= 0; i-- {
+			body = c.stages[i].decode(body)
+		}
+		if !utf8.Valid(body) {
+			return fmt.Errorf("decoding Comix encrypted payload: invalid UTF-8")
+		}
+	}
+
+	var response struct {
+		Status string          `json:"status"`
+		Result json.RawMessage `json:"result"`
+	}
+	if err := json.Unmarshal(body, &response); err != nil {
+		return fmt.Errorf("decoding Comix response JSON: %w", err)
+	}
+	if response.Status != "ok" {
+		return fmt.Errorf("decoding Comix response: unexpected status %q", response.Status)
+	}
+	if len(response.Result) == 0 {
+		return fmt.Errorf("decoding Comix response: missing result")
+	}
+	if err := json.Unmarshal(response.Result, destination); err != nil {
+		return fmt.Errorf("decoding Comix result: %w", err)
+	}
+
+	return nil
+}
+
+func (s comixCodecStage) encode(input []byte) []byte {
+	output := make([]byte, len(input))
+	previous := s.seed
+	for i, value := range input {
+		output[i] = s.table[value^s.key[i%len(s.key)]^previous]
+		previous = output[i]
+	}
+
+	return output
+}
+
+func (s comixCodecStage) decode(input []byte) []byte {
+	output := make([]byte, len(input))
+	previous := s.seed
+	for i, value := range input {
+		output[i] = s.inverse[value] ^ s.key[i%len(s.key)] ^ previous
+		previous = value
+	}
+
+	return output
+}
+
+func canonicalComixRequest(rawURL string, params comixParams) (string, error) {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return "", fmt.Errorf("parsing Comix request URL: %w", err)
+	}
+
+	path := parsed.Path
+	if path == comixAPIPath {
+		path = ""
+	} else if strings.HasPrefix(path, comixAPIPath+"/") {
+		path = strings.TrimPrefix(path, comixAPIPath)
+	}
+	if !isComixProtectedPath(path) {
+		return "", fmt.Errorf("unsupported Comix token path %q", path)
+	}
+
+	pairs := make([]string, 0, len(params))
+	if err := flattenComixParams(&pairs, "", reflect.ValueOf(map[string]any(params))); err != nil {
+		return "", err
+	}
+	if len(pairs) > 0 {
+		path += "?" + strings.Join(pairs, "&")
+	}
+
+	return path, nil
+}
+
+func flattenComixParams(pairs *[]string, prefix string, value reflect.Value) error {
+	if !value.IsValid() || value.Kind() == reflect.Interface && value.IsNil() {
+		return nil
+	}
+	for value.Kind() == reflect.Interface || value.Kind() == reflect.Pointer {
+		if value.IsNil() {
+			return nil
+		}
+		value = value.Elem()
+	}
+
+	switch value.Kind() {
+	case reflect.Map:
+		keys := value.MapKeys()
+		sort.Slice(keys, func(i, j int) bool {
+			return fmt.Sprint(keys[i].Interface()) < fmt.Sprint(keys[j].Interface())
+		})
+		for _, key := range keys {
+			name := fmt.Sprint(key.Interface())
+			if name == comixTokenParameter {
+				continue
+			}
+			nested := name
+			if prefix != "" {
+				nested = prefix + "[" + name + "]"
+			}
+			if err := flattenComixParams(pairs, nested, value.MapIndex(key)); err != nil {
+				return err
+			}
+		}
+	case reflect.Array, reflect.Slice:
+		if value.Kind() == reflect.Slice && value.IsNil() {
+			return nil
+		}
+		for i := range value.Len() {
+			if err := flattenComixParams(pairs, prefix+"["+strconv.Itoa(i)+"]", value.Index(i)); err != nil {
+				return err
+			}
+		}
+	case reflect.String:
+		*pairs = append(*pairs, prefix+"="+value.String())
+	case reflect.Bool:
+		*pairs = append(*pairs, prefix+"="+strconv.FormatBool(value.Bool()))
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		*pairs = append(*pairs, prefix+"="+strconv.FormatInt(value.Int(), 10))
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		*pairs = append(*pairs, prefix+"="+strconv.FormatUint(value.Uint(), 10))
+	case reflect.Float32, reflect.Float64:
+		*pairs = append(*pairs, prefix+"="+strconv.FormatFloat(value.Float(), 'g', -1, value.Type().Bits()))
+	default:
+		return fmt.Errorf("canonicalizing Comix parameter %q: unsupported type %s", prefix, value.Type())
+	}
+
+	return nil
+}
+
+func isComixProtectedPath(path string) bool {
+	if path == "/manga" || strings.HasPrefix(path, "/manga/") {
+		return true
+	}
+	if strings.HasPrefix(path, "/chapters/") {
+		chapterID := strings.TrimPrefix(path, "/chapters/")
+		return chapterID != "" && !strings.Contains(chapterID, "/")
+	}
+	if !strings.HasPrefix(path, "/groups/") || !strings.HasSuffix(path, "/chapters") {
+		return false
+	}
+
+	groupID := strings.TrimSuffix(strings.TrimPrefix(path, "/groups/"), "/chapters")
+	if groupID == "" {
+		return false
+	}
+	for _, character := range groupID {
+		if character < '0' || character > '9' {
+			return false
+		}
+	}
+
+	return true
+}

--- a/internal/source/comix_test.go
+++ b/internal/source/comix_test.go
@@ -1,16 +1,322 @@
 package source
 
 import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
 	"testing"
+
+	"mangarr/internal/domain"
 
 	"github.com/stretchr/testify/require"
 )
 
-func TestComixValidateInputDeprecated(t *testing.T) {
+func TestComixValidateInput(t *testing.T) {
 	t.Parallel()
 
 	src := NewComix("https://comix.to/title/pvry-one-piece", "")
+	require.NoError(t, src.ValidateInput())
 
-	err := src.ValidateInput()
-	require.EqualError(t, err, comixDeprecatedError)
+	src = NewComix("https://example.com/title/pvry-one-piece", "")
+	require.EqualError(t, src.ValidateInput(), "URL must use https://comix.to")
+
+	src = NewComix("https://comix.to/title/pvry-one-piece", "not-numeric")
+	require.ErrorContains(t, src.ValidateInput(), "Comix group ID must be numeric")
+}
+
+func TestComixCodecTokenMatchesFrontendBuild(t *testing.T) {
+	t.Parallel()
+
+	codec, err := newComixCodec()
+	require.NoError(t, err)
+
+	token, err := codec.token("https://comix.to/api/v1/manga/pvry/chapters", comixParams{
+		"page":  1,
+		"limit": 20,
+		"order": map[string]any{"number": "desc"},
+	})
+	require.NoError(t, err)
+	require.Equal(t, "IZ-P1pUtAjt3Oig5K1xNJ4A3XDWhN5iWaB2v65-B44CevAKBEF0OAOg-407yPS4VFzRxRsBwdg", token)
+}
+
+func TestCanonicalComixRequestSortsAndFlattensParameters(t *testing.T) {
+	t.Parallel()
+
+	input, err := canonicalComixRequest("/api/v1/manga/pvry?ignored=true", comixParams{
+		"rating": []string{"safe", "suggestive"},
+		"page":   2,
+		"order":  map[string]any{"number": "asc"},
+		"nil":    nil,
+		"_":      "old-token",
+	})
+	require.NoError(t, err)
+	require.Equal(t, "/manga/pvry?order[number]=asc&page=2&rating[0]=safe&rating[1]=suggestive", input)
+}
+
+func TestComixCodecDecodesEncryptedResponse(t *testing.T) {
+	t.Parallel()
+
+	codec, err := newComixCodec()
+	require.NoError(t, err)
+
+	payload := []byte(`{"status":"ok","result":{"id":366,"hid":"pvry","title":"One Piece"}}`)
+	encoded := payload
+	for _, stage := range codec.stages {
+		encoded = stage.encode(encoded)
+	}
+	envelope, err := json.Marshal(map[string]string{"e": base64.RawURLEncoding.EncodeToString(encoded)})
+	require.NoError(t, err)
+
+	var result struct {
+		ID    int    `json:"id"`
+		HID   string `json:"hid"`
+		Title string `json:"title"`
+	}
+	require.NoError(t, codec.decodeResponse(bytes.NewReader(envelope), true, &result))
+	require.Equal(t, 366, result.ID)
+	require.Equal(t, "pvry", result.HID)
+	require.Equal(t, "One Piece", result.Title)
+}
+
+func TestComixCodecDecodesPlainResponse(t *testing.T) {
+	t.Parallel()
+
+	codec, err := newComixCodec()
+	require.NoError(t, err)
+
+	var result struct {
+		HID string `json:"hid"`
+	}
+	err = codec.decodeResponse(bytes.NewBufferString(`{"status":"ok","result":{"hid":"pvry"}}`), false, &result)
+	require.NoError(t, err)
+	require.Equal(t, "pvry", result.HID)
+}
+
+func TestComixCodecRejectsUnsupportedPath(t *testing.T) {
+	t.Parallel()
+
+	codec, err := newComixCodec()
+	require.NoError(t, err)
+
+	_, err = codec.token("https://comix.to/api/v1/user", nil)
+	require.EqualError(t, err, `unsupported Comix token path "/user"`)
+
+	_, err = codec.token("https://comix.to/api/v1/chapters/", nil)
+	require.EqualError(t, err, `unsupported Comix token path "/chapters/"`)
+}
+
+func TestComixCodecRejectsInvalidEnvelope(t *testing.T) {
+	t.Parallel()
+
+	codec, err := newComixCodec()
+	require.NoError(t, err)
+
+	err = codec.decodeResponse(bytes.NewBufferString(`{"e":"not valid!"}`), true, &struct{}{})
+	require.ErrorContains(t, err, "decoding Comix encrypted payload")
+}
+
+func TestComixGetMangaUsesCurrentEncryptedAPI(t *testing.T) {
+	t.Parallel()
+
+	codec, err := newComixCodec()
+	require.NoError(t, err)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/manga/pvry" {
+			t.Errorf("path = %q, want /api/v1/manga/pvry", r.URL.Path)
+		}
+		if r.URL.Query().Get("_") != "IZ-P1pUtAjt3Oig" {
+			t.Errorf("unexpected token %q", r.URL.Query().Get("_"))
+		}
+		if r.Header.Get("X-Requested-With") != "XMLHttpRequest" {
+			t.Errorf("missing XMLHttpRequest header")
+		}
+		writeEncryptedComixResponse(t, w, codec, map[string]any{
+			"id":    366,
+			"hid":   "pvry",
+			"title": "One: Piece",
+			"type":  "manga",
+			"url":   "/title/pvry-one-piece",
+		})
+	}))
+	defer server.Close()
+
+	source := newTestComix(t, server, "https://comix.to/title/pvry-one-piece", "")
+	manga, err := source.GetManga(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, "pvry", manga.ID)
+	require.Equal(t, "One Piece", manga.Title)
+	require.Equal(t, server.URL+"/title/pvry-one-piece", manga.URL)
+	require.False(t, manga.IsManhwa)
+	require.NotNil(t, manga.Chapters)
+}
+
+func TestComixGetChaptersPaginatesAndFiltersGroup(t *testing.T) {
+	t.Parallel()
+
+	codec, err := newComixCodec()
+	require.NoError(t, err)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		page, err := strconv.Atoi(r.URL.Query().Get("page"))
+		if err != nil {
+			t.Errorf("invalid page: %v", err)
+			return
+		}
+		params := comixParams{
+			"group_id": "6594",
+			"limit":    100,
+			"order":    map[string]any{"number": "desc"},
+			"page":     page,
+		}
+		expectedToken, err := codec.token(r.URL.Path, params)
+		if err != nil {
+			t.Errorf("generating expected token: %v", err)
+			return
+		}
+		if r.URL.Query().Get("_") != expectedToken {
+			t.Errorf("token = %q, want %q", r.URL.Query().Get("_"), expectedToken)
+		}
+		if r.URL.Query().Get("order[number]") != "desc" {
+			t.Errorf("missing nested order query")
+		}
+
+		items := []map[string]any{{
+			"id": 100 + page, "mangaId": 366, "number": 12 - page,
+			"name": "Chapter", "groupId": 6594, "url": fmt.Sprintf("/chapter/%d", page),
+		}}
+		if page == 1 {
+			items = append(items, map[string]any{
+				"id": 999, "mangaId": 366, "number": 9,
+				"name": "Wrong group", "groupId": 9431, "url": "/chapter/wrong",
+			})
+		}
+		writeEncryptedComixResponse(t, w, codec, map[string]any{
+			"items": items,
+			"meta":  map[string]any{"page": page, "lastPage": 2},
+		})
+	}))
+	defer server.Close()
+
+	source := newTestComix(t, server, "https://comix.to/title/pvry-one-piece", "6594")
+	manga := domain.Manga{ID: "pvry", Chapters: make(map[domain.ChapterNumber]domain.Chapter)}
+	require.NoError(t, source.GetChapters(t.Context(), manga))
+	require.Len(t, manga.Chapters, 2)
+	require.Equal(t, "101", manga.Chapters[domain.MustParseChapterNumber("11")].ID)
+	require.Equal(t, server.URL+"/chapter/2", manga.Chapters[domain.MustParseChapterNumber("10")].URL)
+}
+
+func TestComixGetImageURLsNormalizesCompactPages(t *testing.T) {
+	t.Parallel()
+
+	codec, err := newComixCodec()
+	require.NoError(t, err)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		writeEncryptedComixResponse(t, w, codec, map[string]any{
+			"id": 101,
+			"pages": map[string]any{
+				"baseUrl": "https://images.example",
+				"items": []map[string]any{
+					{"url": "/one.webp", "width": 800, "height": 1200},
+					{"url": "https://cdn.example/two.webp", "width": 800, "height": 1200},
+				},
+			},
+		})
+	}))
+	defer server.Close()
+
+	source := newTestComix(t, server, "https://comix.to/title/pvry-one-piece", "")
+	chapter := domain.Chapter{ID: "101"}
+	require.NoError(t, source.GetImageURLs(t.Context(), &chapter))
+	require.Len(t, chapter.ImageInfo, 2)
+	require.Equal(t, "https://images.example/one.webp", chapter.ImageInfo[0].ImageURL)
+	require.Equal(t, map[string]string{"Referer": server.URL + "/"}, chapter.ImageInfo[0].RequestHeaders)
+	require.Nil(t, chapter.ImageInfo[0].Processor)
+	require.Equal(t, "https://cdn.example/two.webp", chapter.ImageInfo[1].ImageURL)
+	require.Equal(t, map[string]string{"Referer": server.URL + "/"}, chapter.ImageInfo[1].RequestHeaders)
+	require.Nil(t, chapter.ImageInfo[1].Processor)
+}
+
+func TestComixGetImageURLsMarksScrambledPage(t *testing.T) {
+	t.Parallel()
+
+	codec, err := newComixCodec()
+	require.NoError(t, err)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		writeEncryptedComixResponse(t, w, codec, map[string]any{
+			"id": 101,
+			"pages": []map[string]any{
+				{"url": "https://images.example/one.webp"},
+				{"url": "https://images.example/two.webp", "s": 1},
+			},
+		})
+	}))
+	defer server.Close()
+
+	source := newTestComix(t, server, "https://comix.to/title/pvry-one-piece", "")
+	chapter := domain.Chapter{ID: "101"}
+	require.NoError(t, source.GetImageURLs(t.Context(), &chapter))
+	require.Len(t, chapter.ImageInfo, 2)
+	require.Nil(t, chapter.ImageInfo[0].Processor)
+	require.IsType(t, comixImageProcessor{}, chapter.ImageInfo[1].Processor)
+}
+
+func TestComixExtractIDRequiresCanonicalTitleURL(t *testing.T) {
+	t.Parallel()
+
+	source := NewComix("https://comix.to/title/pvry-one-piece", "").(*comix)
+	mangaID, err := source.extractIDFromURL(source.MangaURL)
+	require.NoError(t, err)
+	require.Equal(t, "pvry", mangaID)
+
+	_, err = source.extractIDFromURL("https://example.com/title/pvry-one-piece")
+	require.EqualError(t, err, "URL must use https://comix.to")
+}
+
+func newTestComix(t *testing.T, server *httptest.Server, mangaURL, groupID string) *comix {
+	t.Helper()
+
+	source := NewComix(mangaURL, groupID).(*comix)
+	source.BaseURL = server.URL
+	source.Client = server.Client()
+
+	return source
+}
+
+func writeEncryptedComixResponse(t *testing.T, w http.ResponseWriter, codec comixCodec, result any) {
+	t.Helper()
+
+	payload, err := json.Marshal(map[string]any{"status": "ok", "result": result})
+	require.NoError(t, err)
+	for _, stage := range codec.stages {
+		payload = stage.encode(payload)
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("x-enc", "1")
+	require.NoError(t, json.NewEncoder(w).Encode(map[string]string{
+		"e": base64.RawURLEncoding.EncodeToString(payload),
+	}))
+}
+
+func Example_comixCodec_token() {
+	codec, err := newComixCodec()
+	if err != nil {
+		panic(err)
+	}
+
+	token, err := codec.token("/api/v1/manga/pvry", nil)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(token)
+	// Output:
+	// IZ-P1pUtAjt3Oig
 }


### PR DESCRIPTION
## Motivation

The Comix adapter was disabled after its old API endpoints disappeared and the current private API began requiring frontend-generated request tokens. Mangarr could no longer discover or download Comix chapters.

## What's new

- Restores Comix metadata, chapter discovery, and page retrieval through the current `/api/v1` response shapes.
- Generates build-specific request tokens and decodes encrypted API response envelopes in pure Go.
- Sends required image headers and reconstructs scrambled image tiles with both current shuffle algorithms.
- Adds a source-owned image processor seam while preserving the existing Manga Plus streaming XOR path.
- Supports optional numeric group selection and documents the private-protocol compatibility risk.

## Tests

- Added fixed vectors for token generation, response decoding, and both tile-order algorithms.
- Added HTTP fixture coverage for metadata, pagination, group filtering, page normalization, and image processing.
- Manually downloaded One Piece chapter 1190 for group `6594`, reconstructed its scrambled page, validated all 16 CBZ entries, and inspected the output for coherent panels and tile boundaries.
