### PR TITLE
fix(cli): return failure status for download errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ mangarr download --help
 mangarr download -d ./downloads -s tcbscans -m "One Piece"
 ```
 
+The command returns a nonzero status when setup, discovery, selection, or any requested chapter download fails.
+
 If you want a different source, the value you pass to `-m` changes by provider. Use the table below.
 
 ## Monitor Mode

--- a/cmd/download.go
+++ b/cmd/download.go
@@ -22,9 +22,10 @@ import (
 )
 
 var downloadCmd = &cobra.Command{
-	Use:   "download",
-	Short: "Download a specified chapter",
-	Run: func(cmd *cobra.Command, _ []string) {
+	Use:          "download",
+	Short:        "Download a specified chapter",
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, _ []string) error {
 		ctx := cmd.Context()
 
 		// init new logger
@@ -35,8 +36,7 @@ var downloadCmd = &cobra.Command{
 		}
 
 		if err := files.IsValidLocation(downloadDirectory); err != nil {
-			log.Error().Err(err).Msgf("Invalid download location")
-			return
+			return fmt.Errorf("invalid download location: %w", err)
 		}
 
 		var s domain.Source
@@ -61,32 +61,27 @@ var downloadCmd = &cobra.Command{
 		case "atsumaru":
 			s = source.NewAtsumaru(manga, group)
 		default:
-			log.Error().Msgf("Invalid source: %s", mangaSource)
-			return
+			return fmt.Errorf("invalid source %q", mangaSource)
 		}
 
 		if err := s.ValidateInput(); err != nil {
-			log.Error().Err(err).Msgf("Invalid input")
-			return
+			return fmt.Errorf("invalid input: %w", err)
 		}
 
 		selectedManga, err := s.GetManga(ctx)
 		if err != nil {
-			log.Error().Err(err).Msgf("Failed to get manga from %s", s)
-			return
+			return fmt.Errorf("getting manga from %s: %w", s, err)
 		}
 
 		if err := s.GetChapters(ctx, selectedManga); err != nil {
-			log.Error().Err(err).Msgf("Failed to get chapters for %s", selectedManga.Title)
-			return
+			return fmt.Errorf("getting chapters for %s: %w", selectedManga.Title, err)
 		}
 
 		var selectedChapterNumbers []domain.ChapterNumber
 
 		firstChapterNr, latestChapterNr, err := parse.MinMaxChapterNumbers(selectedManga.Chapters)
 		if err != nil {
-			log.Error().Err(err).Msgf("Failed to parse chapter number for %s", selectedManga.Title)
-			return
+			return fmt.Errorf("parsing chapter numbers for %s: %w", selectedManga.Title, err)
 		}
 
 		switch {
@@ -99,14 +94,12 @@ var downloadCmd = &cobra.Command{
 		default:
 			selectedChapterNumbers, err = parse.ChapterSelection(chapterNumbers, selectedManga.Chapters)
 			if err != nil {
-				log.Error().Err(err).Msgf("Failed to parse chapter selection for %s", selectedManga.Title)
-				return
+				return fmt.Errorf("parsing chapter selection for %s: %w", selectedManga.Title, err)
 			}
 		}
 
 		if len(selectedChapterNumbers) == 0 {
-			log.Error().Msgf("Failed to find matching chapters in range %s for %s", chapterNumbers, selectedManga.Title)
-			return
+			return fmt.Errorf("finding matching chapters in range %s for %s", chapterNumbers, selectedManga.Title)
 		}
 
 		overwrittenTitle := sanitize.Filename(overwrite)
@@ -121,10 +114,8 @@ var downloadCmd = &cobra.Command{
 		)
 
 		type chapterResult struct {
-			name          string
 			chapterNumber domain.ChapterNumber
 			status        string
-			err           error
 		}
 
 		results := make(chan chapterResult, len(selectedChapterNumbers))
@@ -139,7 +130,6 @@ var downloadCmd = &cobra.Command{
 
 				result := chapterResult{
 					chapterNumber: chapterNumber,
-					name:          fmt.Sprintf("Chapter %s", chapterNumber),
 					status:        chapterStatusFailed,
 				}
 				shouldDelay := true
@@ -155,14 +145,13 @@ var downloadCmd = &cobra.Command{
 
 				selectedChapter, ok := selectedManga.Chapters[chapterNumber]
 				if !ok {
-					result.err = fmt.Errorf("chapter %s not found", chapterNumber)
-					log.Error().Err(result.err).Msgf("Failed to find chapter with number %s", chapterNumber)
+					err := fmt.Errorf("chapter %s not found", chapterNumber)
+					log.Error().Err(err).Msgf("Failed to find chapter with number %s", chapterNumber)
 					return
 				}
 
 				t := templater.New(selectedManga, selectedChapter)
 				templatedName := t.ExecTemplate(naming)
-				result.name = templatedName
 
 				chapterFolder := sanitize.Filename(templatedName)
 				contentPath := filepath.Join(downloadDirectory, selectedManga.Title, chapterFolder+".cbz")
@@ -170,49 +159,44 @@ var downloadCmd = &cobra.Command{
 				if _, err := os.Stat(contentPath); err == nil {
 					log.Info().Msgf("Chapter has already been downloaded, skipping %q", templatedName)
 					result.status = chapterStatusSkipped
-					result.err = nil
 					shouldDelay = false
 					return
 				}
 
 				if err := s.GetImageURLs(ctx, &selectedChapter); err != nil {
-					result.err = err
 					log.Error().Err(err).Msgf("Failed to get image URLs for chapter %s", selectedChapter.Number)
 					return
 				}
 
 				log.Info().Msgf("Downloading %q", templatedName)
 				if err := download.Chapter(ctx, log, contentPath, selectedChapter, selectedManga.IsManhwa, files.CreateCbzArchive); err != nil {
-					result.err = err
 					log.Error().Err(err).Msgf("Failed to download chapter %q", templatedName)
 					return
 				}
 
 				log.Info().Msgf("Finished downloading %q", templatedName)
 				result.status = chapterStatusDownloaded
-				result.err = nil
 			})
 		}
 
 		wg.Wait()
 		close(results)
 
-		if len(selectedChapterNumbers) > 1 {
-			downloaded := 0
-			var skipped []domain.ChapterNumber
-			var failed []domain.ChapterNumber
-
-			for res := range results {
-				switch res.status {
-				case chapterStatusDownloaded:
-					downloaded++
-				case chapterStatusSkipped:
-					skipped = append(skipped, res.chapterNumber)
-				case chapterStatusFailed:
-					failed = append(failed, res.chapterNumber)
-				}
+		downloaded := 0
+		var skipped []domain.ChapterNumber
+		var failed []domain.ChapterNumber
+		for result := range results {
+			switch result.status {
+			case chapterStatusDownloaded:
+				downloaded++
+			case chapterStatusSkipped:
+				skipped = append(skipped, result.chapterNumber)
+			case chapterStatusFailed:
+				failed = append(failed, result.chapterNumber)
 			}
+		}
 
+		if len(selectedChapterNumbers) > 1 {
 			log.Info().Msgf(
 				"Summary: downloaded=%d skipped=%d failed=%d",
 				downloaded,
@@ -226,12 +210,13 @@ var downloadCmd = &cobra.Command{
 			if len(failed) > 0 {
 				log.Info().Msgf("Failed chapters: %s", parse.FormatChapterList(failed))
 			}
-		} else {
-			for res := range results {
-				// drain channel if no summary required
-				_ = res
-			}
 		}
+
+		if len(failed) > 0 {
+			return fmt.Errorf("failed to download chapters: %s", parse.FormatChapterList(failed))
+		}
+
+		return nil
 	},
 }
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1,6 +1,6 @@
 # Usage Reference
 
-Verified against CLI help and config/runtime code on 2026-05-19.
+Verified against CLI help and config/runtime code on 2026-08-07.
 
 Use this doc when the root README is not enough and you need command, config, or operator detail.
 
@@ -32,6 +32,8 @@ Chapter selection flags are mutually exclusive:
 - `-1`, `--first`: first chapter
 - `-C`, `--chapters`: specific chapters or ranges such as `1,3,5` or `1-10`
 - `-A`, `--all`: all available chapters
+
+The command returns status 0 when all requested chapters are downloaded or already exist. It returns a nonzero status when setup, discovery, selection, or any requested chapter download fails.
 
 Examples:
 

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func TestMainReturnsFailureForInvalidDownloadDirectory(t *testing.T) {
+	const (
+		helperEnvironment    = "MANGARR_TEST_INVALID_DOWNLOAD_DIRECTORY"
+		directoryEnvironment = "MANGARR_TEST_DOWNLOAD_DIRECTORY"
+	)
+	if os.Getenv(helperEnvironment) == "1" {
+		os.Args = []string{
+			"mangarr",
+			"download", "--downloadDirectory", os.Getenv(directoryEnvironment),
+			"--source", "comix",
+			"--manga", "https://comix.to/title/pvry-one-piece",
+		}
+		main()
+		return
+	}
+
+	missingDirectory := filepath.Join(t.TempDir(), "missing")
+	command := exec.Command(os.Args[0], "-test.run=^TestMainReturnsFailureForInvalidDownloadDirectory$")
+	command.Env = append(
+		os.Environ(),
+		helperEnvironment+"=1",
+		directoryEnvironment+"="+missingDirectory,
+	)
+	output, err := command.CombinedOutput()
+	if err == nil {
+		t.Fatalf("mangarr exited successfully for an invalid download directory:\n%s", output)
+	}
+
+	var exitError *exec.ExitError
+	if !errors.As(err, &exitError) {
+		t.Fatalf("running mangarr: %v", err)
+	}
+	if exitError.ExitCode() != 1 {
+		t.Fatalf("mangarr exit code = %d, want 1:\n%s", exitError.ExitCode(), output)
+	}
+}


### PR DESCRIPTION
## Problem

`mangarr download` logged setup and runtime failures but returned status 0. A missing download directory reproduced the problem consistently. The Cobra handler used `Run`, logged each error, and returned normally, so the root command never received an error. Failed chapter workers were also drained or summarized without failing the command.

## Fix

- Change the download handler to `RunE` and return contextual setup, validation, discovery, and selection errors.
- Return an error after result aggregation when any requested chapter fails.
- Keep successful and already-downloaded chapters at status 0.
- Silence usage text for runtime failures and document the exit-status contract.

## Tests

- Add a subprocess regression test that invokes the real `main` boundary with a guaranteed-missing download directory and requires exit code 1.
- Re-run the original built-binary reproduction and confirm the same invalid directory now returns exit code 1.
