### PR TITLE
chore(go): apply toolchain modernizations

### DIFF
--- a/internal/source/asurascans.go
+++ b/internal/source/asurascans.go
@@ -23,8 +23,10 @@ import (
 
 const asurascansBaseURL = "https://asurascans.com"
 
-var asurascansChapterAssetPattern = regexp.MustCompile(`https://cdn\.asurascans\.com/asura-images/chapters/[^"&<]+`)
-var asurascansLockedChapterPattern = regexp.MustCompile(`"number":\[0,(\d+(?:\.\d+)?)\][^}]*"is_locked":\[0,true\]`)
+var (
+	asurascansChapterAssetPattern  = regexp.MustCompile(`https://cdn\.asurascans\.com/asura-images/chapters/[^"&<]+`)
+	asurascansLockedChapterPattern = regexp.MustCompile(`"number":\[0,(\d+(?:\.\d+)?)\][^}]*"is_locked":\[0,true\]`)
+)
 
 type asurascans struct {
 	MangaURL  string

--- a/internal/source/comix_protocol.go
+++ b/internal/source/comix_protocol.go
@@ -263,8 +263,8 @@ func isComixProtectedPath(path string) bool {
 	if path == "/manga" || strings.HasPrefix(path, "/manga/") {
 		return true
 	}
-	if strings.HasPrefix(path, "/chapters/") {
-		chapterID := strings.TrimPrefix(path, "/chapters/")
+	if after, ok := strings.CutPrefix(path, "/chapters/"); ok {
+		chapterID := after
 		return chapterID != "" && !strings.Contains(chapterID, "/")
 	}
 	if !strings.HasPrefix(path, "/groups/") || !strings.HasSuffix(path, "/chapters") {


### PR DESCRIPTION
## Why

The exit-code fix exposed two unrelated changes from the repository's required Go modernization and formatting tools. Keeping them out of the bug fix preserved its scope, but the generated cleanup is still useful as a separate follow-up.

## What changed

- Use `strings.CutPrefix` when extracting protected Comix chapter paths.
- Group adjacent Asura Scans regular-expression variables in the canonical `gofumpt` form.
- Preserve source parsing and protocol behavior.

## Tests

- Re-ran the existing Comix protected-path and Asura Scans parser regression tests.
