### PR TITLE
fix(files): publish archives atomically

### DIFF
--- a/docs/RELIABILITY.md
+++ b/docs/RELIABILITY.md
@@ -15,6 +15,7 @@ Verified on 2026-03-26.
 - shared retry policy in `internal/sharedhttp/`
 - bounded concurrency via semaphores
 - skip-on-existing archive behavior
+- atomic archive publication after ZIP writers and files close successfully
 - optional `pprof` endpoint for runtime inspection
 - config reload without full process restart
 

--- a/docs/exec-plans/active/2026-08-07-codebase-reliability-stack.md
+++ b/docs/exec-plans/active/2026-08-07-codebase-reliability-stack.md
@@ -86,3 +86,14 @@ for code, generated output, dependencies, documentation, and release inputs.
 
 Notes/risks: CI installs pinned Go and YAML tools. GitHub actions follow the
 repository's existing major-version pinning convention.
+
+## Bucket 2 - Atomic archive publication - ALIGNED
+
+Built: Archive output now uses a same-directory temporary file, verifies ZIP and
+file completion, and renames only after success. Empty archives and non-directory
+destinations fail validation.
+
+Serves goal/decision because: Failed writes can no longer leave a final CBZ that
+later monitor or download runs mistake for a completed chapter.
+
+Notes/risks: Atomic replacement follows the host filesystem's rename semantics.

--- a/internal/download/download.go
+++ b/internal/download/download.go
@@ -104,13 +104,9 @@ func downloadImage(ctx context.Context, log zerolog.Logger, imageInfo domain.Ima
 
 		if imageInfo.Processor != nil {
 			filename = filenameNoExt + imageInfo.Processor.Extension()
-			out, err := os.Create(filename)
-			if err != nil {
-				return fmt.Errorf("creating file %s: %w", filename, err)
-			}
-			defer out.Close()
-
-			if err := imageInfo.Processor.Process(resp.Header, src, out); err != nil {
+			if err := writeImageFile(filename, func(out io.Writer) error {
+				return imageInfo.Processor.Process(resp.Header, src, out)
+			}); err != nil {
 				return retry.Unrecoverable(err)
 			}
 
@@ -127,19 +123,33 @@ func downloadImage(ctx context.Context, log zerolog.Logger, imageInfo domain.Ima
 			return retry.Unrecoverable(err)
 		}
 
-		out, err := os.Create(filename)
-		if err != nil {
-			return fmt.Errorf("creating file %s: %w", filename, err)
-		}
-		defer out.Close()
-
-		if _, err = io.Copy(out, src); err != nil {
-			return fmt.Errorf("writing file %s: %w", filename, err)
+		if err := writeImageFile(filename, func(out io.Writer) error {
+			_, err := io.Copy(out, src)
+			return err
+		}); err != nil {
+			return err
 		}
 
 		return nil
 	}); err != nil {
 		return wrapImageError(imageIndex, imageTotal, imageInfo.ImageURL, err)
+	}
+
+	return nil
+}
+
+func writeImageFile(filename string, write func(io.Writer) error) error {
+	out, err := os.Create(filename)
+	if err != nil {
+		return fmt.Errorf("creating file %s: %w", filename, err)
+	}
+
+	if err := write(out); err != nil {
+		_ = out.Close()
+		return fmt.Errorf("writing file %s: %w", filename, err)
+	}
+	if err := out.Close(); err != nil {
+		return fmt.Errorf("closing file %s: %w", filename, err)
 	}
 
 	return nil

--- a/internal/files/files.go
+++ b/internal/files/files.go
@@ -33,8 +33,12 @@ type imageMeta struct {
 }
 
 func IsValidLocation(location string) error {
-	if _, err := os.Stat(location); err != nil {
+	info, err := os.Stat(location)
+	if err != nil {
 		return fmt.Errorf("stat location %s: %w", location, err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("location %s is not a directory", location)
 	}
 
 	return nil
@@ -107,18 +111,7 @@ func CreateCbzArchive(log zerolog.Logger, sourceDir, cbzPath string, isManhwa bo
 	// Sort images lexicographically so they stay in page order.
 	sort.Slice(images, func(i, j int) bool { return images[i].name < images[j].name })
 
-	cbzFile, createErr := os.Create(cbzPath)
-	if createErr != nil {
-		return fmt.Errorf("creating %s: %w", cbzPath, createErr)
-	}
-	defer cbzFile.Close()
-
-	bufWriter := bufio.NewWriter(cbzFile)
-	defer bufWriter.Flush()
-
-	zipWriter := zip.NewWriter(bufWriter)
-	defer zipWriter.Close()
-
+	selectedImages := make([]imageMeta, 0, len(images))
 	for _, img := range images {
 		// Skip pages that are highly likely not a Manhwa page
 		if isManhwa && isLikelyUnwanted(img, mostCommonW) {
@@ -127,11 +120,68 @@ func CreateCbzArchive(log zerolog.Logger, sourceDir, cbzPath string, isManhwa bo
 				Msg("skipped image because it's likely not a Manhwa page")
 			continue
 		}
-		if addErr := addFileToZip(zipWriter, img.path, img.name); addErr != nil {
-			return addErr
-		}
+		selectedImages = append(selectedImages, img)
+	}
+	if len(selectedImages) == 0 {
+		return fmt.Errorf("creating archive: no images to write")
 	}
 
+	if err := publishFileAtomically(cbzPath, func(destination io.Writer) error {
+		zipWriter := zip.NewWriter(destination)
+		for _, img := range selectedImages {
+			if err := addFileToZip(zipWriter, img.path, img.name); err != nil {
+				_ = zipWriter.Close()
+				return err
+			}
+		}
+
+		if err := zipWriter.Close(); err != nil {
+			return fmt.Errorf("closing zip archive: %w", err)
+		}
+
+		return nil
+	}); err != nil {
+		return fmt.Errorf("publishing %s: %w", cbzPath, err)
+	}
+
+	return nil
+}
+
+func publishFileAtomically(destinationPath string, write func(io.Writer) error) (err error) {
+	destinationDir := filepath.Dir(destinationPath)
+	tmpFile, err := os.CreateTemp(destinationDir, "."+filepath.Base(destinationPath)+".tmp-*")
+	if err != nil {
+		return fmt.Errorf("creating temporary file: %w", err)
+	}
+
+	tmpPath := tmpFile.Name()
+	published := false
+	defer func() {
+		if published {
+			return
+		}
+
+		_ = tmpFile.Close()
+		_ = os.Remove(tmpPath)
+	}()
+
+	if err := tmpFile.Chmod(0o644); err != nil {
+		return fmt.Errorf("setting temporary file permissions: %w", err)
+	}
+	if err := write(tmpFile); err != nil {
+		return err
+	}
+	if err := tmpFile.Sync(); err != nil {
+		return fmt.Errorf("syncing temporary file: %w", err)
+	}
+	if err := tmpFile.Close(); err != nil {
+		return fmt.Errorf("closing temporary file: %w", err)
+	}
+	if err := os.Rename(tmpPath, destinationPath); err != nil {
+		return fmt.Errorf("renaming temporary file: %w", err)
+	}
+
+	published = true
 	return nil
 }
 

--- a/internal/files/files_test.go
+++ b/internal/files/files_test.go
@@ -2,9 +2,11 @@ package files
 
 import (
 	"archive/zip"
+	"errors"
 	"image"
 	"image/color"
 	"image/png"
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -50,5 +52,65 @@ func TestCreateCbzArchiveFlushesOutput(t *testing.T) {
 
 	if len(r.File) != 1 {
 		t.Fatalf("expected 1 file in cbz, got %d", len(r.File))
+	}
+}
+
+func TestCreateCbzArchiveDoesNotPublishEmptyArchive(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	sourceDir := filepath.Join(tmpDir, "empty")
+	if err := os.Mkdir(sourceDir, 0o755); err != nil {
+		t.Fatalf("mkdir empty source: %v", err)
+	}
+	outPath := filepath.Join(tmpDir, "out.cbz")
+	err := CreateCbzArchive(zerolog.Nop(), sourceDir, outPath, false)
+
+	if err == nil {
+		t.Fatal("expected empty source directory to fail")
+	}
+	if _, statErr := os.Stat(outPath); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("final archive exists after failure: %v", statErr)
+	}
+}
+
+func TestPublishFileAtomicallyRemovesPartialOutput(t *testing.T) {
+	t.Parallel()
+
+	destination := filepath.Join(t.TempDir(), "chapter.cbz")
+	wantErr := errors.New("simulated write failure")
+	err := publishFileAtomically(destination, func(writer io.Writer) error {
+		if _, err := writer.Write([]byte("partial archive")); err != nil {
+			return err
+		}
+		return wantErr
+	})
+
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("publish error = %v, want %v", err, wantErr)
+	}
+	if _, statErr := os.Stat(destination); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("final file exists after failure: %v", statErr)
+	}
+
+	matches, globErr := filepath.Glob(filepath.Join(filepath.Dir(destination), ".chapter.cbz.tmp-*"))
+	if globErr != nil {
+		t.Fatalf("glob temporary files: %v", globErr)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("temporary files remain after failure: %v", matches)
+	}
+}
+
+func TestIsValidLocationRejectsFile(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "not-a-directory")
+	if err := os.WriteFile(path, []byte("file"), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	if err := IsValidLocation(path); err == nil {
+		t.Fatal("expected file location to fail validation")
 	}
 }


### PR DESCRIPTION
<!-- ship-stack:start -->
## PR stack

> [!NOTE]
> This PR is part of a stack. Merge it with the full stack when ready.

Depends on:
- #101

Followed by:
- #103
<!-- ship-stack:end -->

## Problem

Archive creation writes directly to the final CBZ path and ignores deferred close errors. A failed write can leave a partial file that later runs treat as a completed chapter.

## Fix

- Write archives to same-directory temporary files and rename only after successful ZIP close, file sync, and file close.
- Remove temporary output after every failure.
- Reject empty archives and non-directory download locations.
- Report image output close failures.

## Tests

- Added regression coverage for partial-write cleanup.
- Added empty-archive and invalid-location coverage.
- Kept the successful archive readability test.
