### PR TITLE
fix(monitor): reload validated config snapshots

### DIFF
--- a/cmd/monitor.go
+++ b/cmd/monitor.go
@@ -6,46 +6,54 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
-	"sync"
 	"syscall"
 	"time"
 
 	"mangarr/internal/buildinfo"
 	"mangarr/internal/config"
+	"mangarr/internal/domain"
 	"mangarr/internal/download"
 	"mangarr/internal/files"
 	"mangarr/internal/logger"
 	"mangarr/internal/parse"
 	"mangarr/internal/perf"
 	"mangarr/internal/sanitize"
-	"mangarr/internal/semaphore"
 	"mangarr/internal/source"
 	"mangarr/internal/templater"
 
 	"github.com/spf13/cobra"
+	"golang.org/x/sync/errgroup"
 )
 
 var monitorCmd = &cobra.Command{
 	Use:   "monitor",
 	Short: "Monitor a specified manga for new chapters",
 	Run: func(cmd *cobra.Command, _ []string) {
-		runCtx, cancel := context.WithCancel(cmd.Context())
-		defer cancel()
+		runCtx, stop := signal.NotifyContext(
+			cmd.Context(),
+			syscall.SIGHUP,
+			syscall.SIGINT,
+			syscall.SIGQUIT,
+			syscall.SIGTERM,
+		)
+		defer stop()
 
-		// read config
 		cfg := config.New(configPath, buildinfo.Version)
+		snapshot := cfg.Snapshot()
 
-		// init new logger
-		log := logger.New(cfg.Config)
+		log := logger.New(&snapshot)
 
 		if err := cfg.UpdateConfig(); err != nil {
-			log.Error().Err(err).Msgf("error updating config")
+			log.Error().Err(err).Msg("error updating config")
 		}
 
-		// init dynamic config
-		cfg.DynamicReload(log)
+		reloads, err := cfg.DynamicReload(log)
+		if err != nil {
+			log.Error().Err(err).Msg("dynamic config reload disabled")
+			reloads = make(chan struct{})
+		}
 
-		if err := files.IsValidLocation(cfg.Config.DownloadLocation); err != nil {
+		if err := files.IsValidLocation(snapshot.DownloadLocation); err != nil {
 			log.Fatal().Err(err).Msgf("invalid download location")
 		}
 
@@ -53,115 +61,117 @@ var monitorCmd = &cobra.Command{
 		log.Info().Msgf("Version: %s", buildinfo.Version)
 		log.Info().Msgf("Commit: %s", buildinfo.Commit)
 		log.Info().Msgf("Build date: %s", buildinfo.Date)
-		log.Info().Msgf("Log-level: %s", cfg.Config.LogLevel)
+		log.Info().Msgf("Log-level: %s", snapshot.LogLevel)
 
-		if cfg.Config.PprofEnabled {
-			pprofAddress, err := perf.StartPprofServer(runCtx, log, cfg.Config.PprofAddress)
+		if snapshot.PprofEnabled {
+			pprofAddress, err := perf.StartPprofServer(runCtx, log, snapshot.PprofAddress)
 			if err != nil {
-				log.Error().Err(err).Msgf("error starting pprof endpoint")
+				log.Error().Err(err).Msg("error starting pprof endpoint")
 			} else {
 				log.Info().Msgf("pprof endpoint available at http://%s/debug/pprof/", pprofAddress)
 			}
 		}
 
-		ticker := time.NewTicker(cfg.Config.CheckInterval * time.Minute)
-		defer ticker.Stop()
+		runMonitorCycle(runCtx, snapshot, log)
 
-		// semaphore to limit concurrency to maxConcurrentSourceProcesses which is set to 10
-		sem := semaphore.NewWeighted(maxConcurrentSourceProcesses)
-		quit := make(chan bool, 1)
-		var wg sync.WaitGroup
-
-		go func() {
-			for {
-				select {
-				case <-quit:
-					return
-				case <-ticker.C:
-					for mangaTitle, monitoredManga := range cfg.Config.MonitoredManga {
-						wg.Go(func() {
-							sem.Acquire()
-							defer sem.Release()
-
-							mangaSource, err := source.Select(*monitoredManga)
-							if err != nil {
-								log.Error().Err(err).Msgf("error selecting manga source")
-								return
-							}
-							mLog := log.With().Str("manga", mangaTitle).Str("source", mangaSource.String()).Logger()
-
-							if err := mangaSource.ValidateInput(); err != nil {
-								mLog.Error().Err(err).Msgf("error validating input")
-								return
-							}
-
-							selectedManga, err := mangaSource.GetManga(runCtx)
-							if err != nil {
-								mLog.Error().Err(err).Msgf("error getting manga from %s", monitoredManga.Source)
-								return
-							}
-
-							if err := mangaSource.GetChapters(runCtx, selectedManga); err != nil {
-								mLog.Error().Err(err).Msg("error getting manga chapters")
-								return
-							}
-
-							_, latestChapterNr, err := parse.MinMaxChapterNumbers(selectedManga.Chapters)
-							if err != nil {
-								mLog.Error().Err(err).Msg("error getting latest chapter number")
-								return
-							}
-
-							selectedChapter, ok := selectedManga.Chapters[latestChapterNr]
-							if !ok {
-								mLog.Error().Msgf("error finding chapter with number %s", latestChapterNr)
-								return
-							}
-
-							overwrittenTitle := sanitize.Filename(monitoredManga.Overwrite)
-
-							if len(overwrittenTitle) != 0 {
-								selectedManga.Title = overwrittenTitle
-							}
-
-							t := templater.New(selectedManga, selectedChapter)
-							templatedName := t.ExecTemplate(cfg.Config.NamingTemplate)
-
-							chapterFolder := sanitize.Filename(templatedName)
-							contentPath := filepath.Join(cfg.Config.DownloadLocation, selectedManga.Title, chapterFolder+".cbz")
-
-							if _, err := os.Stat(contentPath); err == nil {
-								mLog.Debug().Msgf("chapter has already been downloaded, skipping %s", templatedName)
-								return
-							}
-
-							if err := mangaSource.GetImageURLs(runCtx, &selectedChapter); err != nil {
-								mLog.Error().Err(err).Msgf("error getting image urls for chapter %s", selectedChapter.Number)
-								return
-							}
-
-							mLog.Info().Msgf("downloading %q", templatedName)
-							if err := download.Chapter(runCtx, mLog, contentPath, selectedChapter, selectedManga.IsManhwa, files.CreateCbzArchive); err != nil {
-								mLog.Error().Err(err).Msgf("error downloading chapter %s", templatedName)
-								return
-							}
-							mLog.Info().Msgf("finished downloading %s", templatedName)
-						})
-					}
-
-					wg.Wait()
-				}
+		timer := time.NewTimer(snapshot.CheckInterval * time.Minute)
+		defer timer.Stop()
+		for {
+			select {
+			case <-runCtx.Done():
+				log.Info().Msg("stopping monitoring")
+				return
+			case <-reloads:
+				snapshot = cfg.Snapshot()
+				resetTimer(timer, snapshot.CheckInterval*time.Minute)
+			case <-timer.C:
+				snapshot = cfg.Snapshot()
+				runMonitorCycle(runCtx, snapshot, log)
+				timer.Reset(snapshot.CheckInterval * time.Minute)
 			}
-		}()
-
-		// set up a channel to catch signals for graceful shutdown
-		sigCh := make(chan os.Signal, 1)
-		signal.Notify(sigCh, syscall.SIGHUP, syscall.SIGINT, syscall.SIGQUIT, syscall.SIGTERM)
-
-		sig := <-sigCh
-		fmt.Printf("received signal: %s, stopping monitoring.\n", sig)
-		cancel()
-		quit <- true
-		wg.Wait()
+		}
 	},
+}
+
+func resetTimer(timer *time.Timer, duration time.Duration) {
+	if !timer.Stop() {
+		select {
+		case <-timer.C:
+		default:
+		}
+	}
+	timer.Reset(duration)
+}
+
+func runMonitorCycle(ctx context.Context, cfg domain.Config, log logger.Logger) {
+	if err := files.IsValidLocation(cfg.DownloadLocation); err != nil {
+		log.Error().Err(err).Msg("invalid download location")
+		return
+	}
+
+	group, groupCtx := errgroup.WithContext(ctx)
+	group.SetLimit(maxConcurrentSourceProcesses)
+	for mangaTitle, monitoredManga := range cfg.MonitoredManga {
+		group.Go(func() error {
+			if err := monitorManga(groupCtx, cfg, mangaTitle, *monitoredManga, log); err != nil {
+				log.Error().Err(err).Str("manga", mangaTitle).Msg("monitor check failed")
+			}
+			return nil
+		})
+	}
+	_ = group.Wait()
+}
+
+func monitorManga(ctx context.Context, cfg domain.Config, mangaTitle string, monitoredManga domain.MonitoredManga, log logger.Logger) error {
+	mangaSource, err := source.Select(monitoredManga)
+	if err != nil {
+		return fmt.Errorf("selecting manga source: %w", err)
+	}
+	mLog := log.With().Str("manga", mangaTitle).Str("source", mangaSource.String()).Logger()
+
+	if err := mangaSource.ValidateInput(); err != nil {
+		return fmt.Errorf("validating input: %w", err)
+	}
+
+	selectedManga, err := mangaSource.GetManga(ctx)
+	if err != nil {
+		return fmt.Errorf("getting manga from %s: %w", monitoredManga.Source, err)
+	}
+	if err := mangaSource.GetChapters(ctx, selectedManga); err != nil {
+		return fmt.Errorf("getting manga chapters: %w", err)
+	}
+
+	_, latestChapterNr, err := parse.MinMaxChapterNumbers(selectedManga.Chapters)
+	if err != nil {
+		return fmt.Errorf("getting latest chapter number: %w", err)
+	}
+	selectedChapter, ok := selectedManga.Chapters[latestChapterNr]
+	if !ok {
+		return fmt.Errorf("finding chapter with number %s", latestChapterNr)
+	}
+
+	if overwrittenTitle := sanitize.Filename(monitoredManga.Overwrite); overwrittenTitle != "" {
+		selectedManga.Title = overwrittenTitle
+	}
+
+	t := templater.New(selectedManga, selectedChapter)
+	templatedName := t.ExecTemplate(cfg.NamingTemplate)
+	chapterFolder := sanitize.Filename(templatedName)
+	contentPath := filepath.Join(cfg.DownloadLocation, selectedManga.Title, chapterFolder+".cbz")
+	if _, err := os.Stat(contentPath); err == nil {
+		mLog.Debug().Msgf("chapter has already been downloaded, skipping %s", templatedName)
+		return nil
+	}
+
+	if err := mangaSource.GetImageURLs(ctx, &selectedChapter); err != nil {
+		return fmt.Errorf("getting image URLs for chapter %s: %w", selectedChapter.Number, err)
+	}
+
+	mLog.Info().Msgf("downloading %q", templatedName)
+	if err := download.Chapter(ctx, mLog, contentPath, selectedChapter, selectedManga.IsManhwa, files.CreateCbzArchive); err != nil {
+		return fmt.Errorf("downloading chapter %s: %w", templatedName, err)
+	}
+	mLog.Info().Msgf("finished downloading %s", templatedName)
+
+	return nil
 }

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -127,6 +127,11 @@ Environment overrides use the `MANGARR__` prefix:
 - `MANGARR__LOG_MAX_SIZE`
 - `MANGARR__LOG_MAX_BACKUPS`
 
+Monitor checks all configured manga once at startup. It then waits for the check
+interval. Changes to monitored manga, naming, download location, check interval,
+and log level reload while monitor runs. Environment overrides are reapplied to
+each reload. Changes to pprof and log file output settings require a restart.
+
 ### `version`
 
 Show local build/version info.

--- a/docs/design-docs/runtime-model.md
+++ b/docs/design-docs/runtime-model.md
@@ -31,7 +31,9 @@ Semaphores cap concurrency. The code favors bounded parallelism over unbounded g
 - defaults are embedded in Go structs/template text
 - config path lookup falls back through local and home-directory locations
 - env overrides use `MANGARR__` prefix
-- monitor mode can reload config while running
+- monitor mode publishes validated immutable config snapshots while running
+- monitored manga, naming, download location, interval, and log level reload live
+- pprof and log output destinations require a restart
 
 ## Operational Risk
 

--- a/docs/exec-plans/active/2026-08-07-codebase-reliability-stack.md
+++ b/docs/exec-plans/active/2026-08-07-codebase-reliability-stack.md
@@ -97,3 +97,16 @@ Serves goal/decision because: Failed writes can no longer leave a final CBZ that
 later monitor or download runs mistake for a completed chapter.
 
 Notes/risks: Atomic replacement follows the host filesystem's rename semantics.
+
+## Bucket 3 - Monitor configuration and lifecycle - ALIGNED
+
+Built: Config loads into validated immutable snapshots, reload publishes only
+valid snapshots, and monitor runs immediately with a reload-aware timer and
+context-driven shutdown.
+
+Serves goal/decision because: Monitor no longer reads maps while a watcher mutates
+them, invalid intervals cannot panic the scheduler, and runtime behavior matches
+the operator contract.
+
+Notes/risks: Pprof and log destination changes remain restart-only because those
+resources are constructed once at process startup.

--- a/docs/product-specs/monitoring-operator.md
+++ b/docs/product-specs/monitoring-operator.md
@@ -19,3 +19,5 @@ Run `mangarr monitor` unattended and trust it to fetch new chapters without cons
 - monitor logs remain actionable for source failures
 - failure handling does not corrupt already-downloaded archives
 - source-specific runtime requirements stay documented when they appear
+- monitor checks configured manga once at startup before waiting for the interval
+- invalid reloads keep the last valid config snapshot active

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,14 +1,14 @@
 package config
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"os"
-	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
-	"sync"
+	"sync/atomic"
 	"time"
 
 	"mangarr/internal/domain"
@@ -18,7 +18,6 @@ import (
 	"github.com/knadh/koanf/providers/file"
 	"github.com/knadh/koanf/providers/structs"
 	"github.com/knadh/koanf/v2"
-	"github.com/pkg/errors"
 )
 
 var configTemplate = `# config.yaml
@@ -164,7 +163,7 @@ logLevel: "DEBUG"
 #logMaxBackups = 3
 `
 
-func (c *AppConfig) writeConfig(configPath string, configFile string) error {
+func writeConfig(configPath string, configFile string) error {
 	cfgPath := filepath.Join(configPath, configFile)
 
 	// check if configPath exists, if not create it
@@ -198,198 +197,240 @@ func (c *AppConfig) writeConfig(configPath string, configFile string) error {
 	return nil
 }
 
-type Config interface {
-	UpdateConfig() error
-	DynamicReload(log logger.Logger)
-}
-
 type AppConfig struct {
-	Config *domain.Config
-	m      *sync.Mutex
-	k      *koanf.Koanf
+	current    atomic.Pointer[domain.Config]
+	configFile string
+	version    string
 }
 
 func New(configPath string, version string) *AppConfig {
-	c := &AppConfig{
-		Config: &domain.Config{
-			Version:    version,
-			ConfigPath: configPath,
-		},
-		m: new(sync.Mutex),
-		k: koanf.New("."),
-	}
-
-	c.defaults()
-	c.load()
-	c.loadFromEnv()
-
-	if c.Config.DownloadLocation == "" {
-		log.Fatalf("downloadLocation can't be empty, please provide a valid path to the directory you want your downloads to go to")
+	c, err := Load(configPath, version)
+	if err != nil {
+		log.Fatal(err)
 	}
 
 	return c
 }
 
-func (c *AppConfig) defaults() {
-	c.Config.DownloadLocation = ""
-	c.Config.NamingTemplate = "{manga:<.>} Ch. {num:3}"
-	c.Config.CheckInterval = 15
-	c.Config.PprofEnabled = false
-	c.Config.PprofAddress = "127.0.0.1:6060"
-	c.Config.MonitoredManga = make(map[string]*domain.MonitoredManga)
-	c.Config.LogPath = ""
-	c.Config.LogLevel = "DEBUG"
-	c.Config.LogMaxSize = 50
-	c.Config.LogMaxBackups = 3
+func Load(configPath string, version string) (*AppConfig, error) {
+	configFile, err := resolveConfigFile(configPath)
+	if err != nil {
+		return nil, err
+	}
 
-	// load default values into koanf
-	if err := c.k.Load(structs.Provider(c.Config, "yaml"), nil); err != nil {
-		log.Fatalf("could not load default values into config: %q", err)
+	c := &AppConfig{configFile: configFile, version: version}
+	snapshot, err := c.loadSnapshot()
+	if err != nil {
+		return nil, err
+	}
+	c.current.Store(snapshot)
+
+	return c, nil
+}
+
+func defaultConfig(version, configFile string) domain.Config {
+	return domain.Config{
+		Version:        version,
+		ConfigPath:     filepath.Dir(configFile),
+		NamingTemplate: "{manga:<.>} Ch. {num:3}{title: - <.>}",
+		CheckInterval:  15,
+		PprofAddress:   "127.0.0.1:6060",
+		MonitoredManga: make(map[string]*domain.MonitoredManga),
+		LogLevel:       "DEBUG",
+		LogMaxSize:     50,
+		LogMaxBackups:  3,
 	}
 }
 
-func (c *AppConfig) loadFromEnv() {
-	prefix := "MANGARR__"
+func resolveConfigFile(configPath string) (string, error) {
+	if configPath != "" {
+		cleanPath := filepath.Clean(configPath)
+		if err := writeConfig(cleanPath, "config.yaml"); err != nil {
+			return "", fmt.Errorf("writing config template: %w", err)
+		}
+
+		return filepath.Join(cleanPath, "config.yaml"), nil
+	}
+
+	locations := []string{
+		"./config.yaml",
+		"$HOME/.config/mangarr/config.yaml",
+		"$HOME/.mangarr/config.yaml",
+	}
+	for _, location := range locations {
+		expanded := os.ExpandEnv(location)
+		if _, err := os.Stat(expanded); err == nil {
+			return expanded, nil
+		}
+	}
+
+	return "", fmt.Errorf("could not find config file")
+}
+
+func (c *AppConfig) loadSnapshot() (*domain.Config, error) {
+	cfg := defaultConfig(c.version, c.configFile)
+	k := koanf.New(".")
+	if err := k.Load(structs.Provider(&cfg, "yaml"), nil); err != nil {
+		return nil, fmt.Errorf("loading config defaults: %w", err)
+	}
+	if err := k.Load(file.Provider(c.configFile), yaml.Parser()); err != nil {
+		return nil, fmt.Errorf("reading config file %s: %w", c.configFile, err)
+	}
+	if err := k.Unmarshal("", &cfg); err != nil {
+		return nil, fmt.Errorf("decoding config file %s: %w", c.configFile, err)
+	}
+
+	applyEnvironment(&cfg)
+	if err := validate(cfg); err != nil {
+		return nil, fmt.Errorf("validating config file %s: %w", c.configFile, err)
+	}
+
+	snapshot := cloneConfig(cfg)
+	return &snapshot, nil
+}
+
+func applyEnvironment(cfg *domain.Config) {
+	const prefix = "MANGARR__"
 
 	envs := os.Environ()
 	for _, env := range envs {
-		if strings.HasPrefix(env, prefix) {
-			envPair := strings.SplitN(env, "=", 2)
+		if !strings.HasPrefix(env, prefix) {
+			continue
+		}
 
-			if envPair[1] != "" {
-				switch envPair[0] {
-				case prefix + "DOWNLOAD_LOCATION":
-					c.Config.DownloadLocation = envPair[1]
-				case prefix + "NAMING_TEMPLATE":
-					c.Config.NamingTemplate = envPair[1]
-				case prefix + "CHECK_INTERVAL":
-					if i, _ := strconv.ParseInt(envPair[1], 10, 32); i > 0 {
-						c.Config.CheckInterval = time.Duration(i)
-					}
-				case prefix + "PPROF_ENABLED":
-					if b, err := strconv.ParseBool(envPair[1]); err == nil {
-						c.Config.PprofEnabled = b
-					}
-				case prefix + "PPROF_ADDRESS":
-					c.Config.PprofAddress = envPair[1]
-				case prefix + "LOG_LEVEL":
-					c.Config.LogLevel = envPair[1]
-				case prefix + "LOG_PATH":
-					c.Config.LogPath = envPair[1]
-				case prefix + "LOG_MAX_SIZE":
-					if i, _ := strconv.ParseInt(envPair[1], 10, 32); i > 0 {
-						c.Config.LogMaxSize = int(i)
-					}
-				case prefix + "LOG_MAX_BACKUPS":
-					if i, _ := strconv.ParseInt(envPair[1], 10, 32); i > 0 {
-						c.Config.LogMaxBackups = int(i)
-					}
-				}
+		envPair := strings.SplitN(env, "=", 2)
+		if len(envPair) != 2 || envPair[1] == "" {
+			continue
+		}
+
+		switch envPair[0] {
+		case prefix + "DOWNLOAD_LOCATION":
+			cfg.DownloadLocation = envPair[1]
+		case prefix + "NAMING_TEMPLATE":
+			cfg.NamingTemplate = envPair[1]
+		case prefix + "CHECK_INTERVAL":
+			if i, err := strconv.ParseInt(envPair[1], 10, 32); err == nil {
+				cfg.CheckInterval = time.Duration(i)
+			}
+		case prefix + "PPROF_ENABLED":
+			if enabled, err := strconv.ParseBool(envPair[1]); err == nil {
+				cfg.PprofEnabled = enabled
+			}
+		case prefix + "PPROF_ADDRESS":
+			cfg.PprofAddress = envPair[1]
+		case prefix + "LOG_LEVEL":
+			cfg.LogLevel = strings.ToUpper(envPair[1])
+		case prefix + "LOG_PATH":
+			cfg.LogPath = envPair[1]
+		case prefix + "LOG_MAX_SIZE":
+			if i, err := strconv.ParseInt(envPair[1], 10, 32); err == nil {
+				cfg.LogMaxSize = int(i)
+			}
+		case prefix + "LOG_MAX_BACKUPS":
+			if i, err := strconv.ParseInt(envPair[1], 10, 32); err == nil {
+				cfg.LogMaxBackups = int(i)
 			}
 		}
 	}
-
-	if err := c.k.Load(structs.Provider(c.Config, "yaml"), nil); err != nil {
-		log.Fatalf("could not load env vars into config: %q", err)
-	}
 }
 
-func (c *AppConfig) load() {
-	configPath := path.Clean(c.Config.ConfigPath)
-
-	var configFile string
-
-	if configPath != "" {
-		if err := c.writeConfig(configPath, "config.yaml"); err != nil {
-			log.Printf("config write error: %q", err)
-		}
-
-		configFile = path.Join(configPath, "config.yaml")
-	} else {
-		locations := []string{
-			"./config.yaml",
-			"$HOME/.config/mangarr/config.yaml",
-			"$HOME/.mangarr/config.yaml",
-		}
-
-		for _, loc := range locations {
-			expandedLoc := os.ExpandEnv(loc)
-			if _, err := os.Stat(expandedLoc); err == nil {
-				configFile = expandedLoc
-				break
-			}
-		}
-
-		if configFile == "" {
-			log.Fatalf("could not find config file")
-		}
+func validate(cfg domain.Config) error {
+	if cfg.DownloadLocation == "" {
+		return fmt.Errorf("downloadLocation cannot be empty")
 	}
-
-	if err := c.k.Load(file.Provider(configFile), yaml.Parser()); err != nil {
-		log.Fatalf("config read error: %q", err)
+	if cfg.NamingTemplate == "" {
+		return fmt.Errorf("namingTemplate cannot be empty")
 	}
-	c.Config.ConfigPath = filepath.Dir(configFile)
-
-	if err := c.k.Unmarshal("", c.Config); err != nil {
-		log.Fatalf("could not unmarshal config file: %v: err %q", configFile, err)
+	if cfg.CheckInterval <= 0 {
+		return fmt.Errorf("checkInterval must be greater than zero")
 	}
-}
-
-func (c *AppConfig) DynamicReload(log logger.Logger) {
-	configFile := path.Join(c.Config.ConfigPath, "config.yaml")
-
-	f := file.Provider(configFile)
-
-	f.Watch(func(event any, err error) {
-		if err != nil {
-			log.Error().Err(err).Msg("error watching config file")
-			return
-		}
-
-		c.m.Lock()
-		defer c.m.Unlock()
-
-		// create a new koanf instance for reloading
-		k := koanf.New(".")
-
-		// load the config file
-		if err := k.Load(f, yaml.Parser()); err != nil {
-			log.Error().Err(err).Msg("failed to reload config file")
-			return
-		}
-
-		// unmarshal the updated config into the Config struct
-		if err := k.Unmarshal("", c.Config); err != nil {
-			log.Error().Err(err).Msg("failed to unmarshal updated config")
-			return
-		}
-
-		log.SetLogLevel(c.Config.LogLevel)
-
-		log.Debug().Msg("config file reloaded!")
-	})
-}
-
-func (c *AppConfig) UpdateConfig() error {
-	configFile := path.Join(c.Config.ConfigPath, "config.yaml")
-
-	f, err := os.ReadFile(configFile)
-	if err != nil {
-		return fmt.Errorf("could not read config configFile: %s: %w", configFile, err)
+	if cfg.PprofEnabled && cfg.PprofAddress == "" {
+		return fmt.Errorf("pprofAddress cannot be empty when pprof is enabled")
 	}
-
-	lines := strings.Split(string(f), "\n")
-	lines = c.processLines(lines)
-
-	output := strings.Join(lines, "\n")
-	if err := os.WriteFile(configFile, []byte(output), 0o644); err != nil {
-		return fmt.Errorf("could not write config file: %s: %w", configFile, err)
+	switch cfg.LogLevel {
+	case "ERROR", "DEBUG", "INFO", "WARN", "TRACE":
+	default:
+		return fmt.Errorf("unsupported logLevel %q", cfg.LogLevel)
+	}
+	if cfg.LogMaxSize <= 0 {
+		return fmt.Errorf("logMaxSize must be greater than zero")
+	}
+	if cfg.LogMaxBackups <= 0 {
+		return fmt.Errorf("logMaxBackups must be greater than zero")
+	}
+	for name, manga := range cfg.MonitoredManga {
+		if manga == nil {
+			return fmt.Errorf("monitoredManga %q cannot be null", name)
+		}
 	}
 
 	return nil
 }
 
-func (c *AppConfig) processLines(lines []string) []string {
+func (c *AppConfig) Snapshot() domain.Config {
+	return cloneConfig(*c.current.Load())
+}
+
+func cloneConfig(cfg domain.Config) domain.Config {
+	clone := cfg
+	clone.MonitoredManga = make(map[string]*domain.MonitoredManga, len(cfg.MonitoredManga))
+	for name, manga := range cfg.MonitoredManga {
+		mangaClone := *manga
+		clone.MonitoredManga[name] = &mangaClone
+	}
+
+	return clone
+}
+
+func (c *AppConfig) DynamicReload(log logger.Logger) (<-chan struct{}, error) {
+	reloaded := make(chan struct{}, 1)
+	f := file.Provider(c.configFile)
+
+	err := f.Watch(func(_ any, watchErr error) {
+		if watchErr != nil {
+			log.Error().Err(watchErr).Msg("error watching config file")
+			return
+		}
+
+		snapshot, err := c.loadSnapshot()
+		if err != nil {
+			log.Error().Err(err).Msg("config reload rejected")
+			return
+		}
+
+		c.current.Store(snapshot)
+		log.SetLogLevel(snapshot.LogLevel)
+		select {
+		case reloaded <- struct{}{}:
+		default:
+		}
+		log.Debug().Msg("config file reloaded")
+	})
+	if err != nil {
+		return nil, fmt.Errorf("watching config file %s: %w", c.configFile, err)
+	}
+
+	return reloaded, nil
+}
+
+func (c *AppConfig) UpdateConfig() error {
+	f, err := os.ReadFile(c.configFile)
+	if err != nil {
+		return fmt.Errorf("could not read config file %s: %w", c.configFile, err)
+	}
+
+	lines := strings.Split(string(f), "\n")
+	lines = processLines(lines, c.Snapshot())
+
+	output := strings.Join(lines, "\n")
+	if err := os.WriteFile(c.configFile, []byte(output), 0o644); err != nil {
+		return fmt.Errorf("could not write config file %s: %w", c.configFile, err)
+	}
+
+	return nil
+}
+
+func processLines(lines []string, cfg domain.Config) []string {
 	// keep track of not found values to append at the bottom
 	var (
 		foundLineLogLevel     = false
@@ -400,23 +441,23 @@ func (c *AppConfig) processLines(lines []string) []string {
 
 	for i, line := range lines {
 		if !foundLineLogLevel && strings.Contains(line, "logLevel:") {
-			lines[i] = fmt.Sprintf(`logLevel: "%s"`, c.Config.LogLevel)
+			lines[i] = fmt.Sprintf(`logLevel: "%s"`, cfg.LogLevel)
 			foundLineLogLevel = true
 		}
 		if !foundLineLogPath && strings.Contains(line, "logPath:") {
-			if c.Config.LogPath == "" {
+			if cfg.LogPath == "" {
 				lines[i] = `#logPath: ""`
 			} else {
-				lines[i] = fmt.Sprintf(`logPath: "%s"`, c.Config.LogPath)
+				lines[i] = fmt.Sprintf(`logPath: "%s"`, cfg.LogPath)
 			}
 			foundLineLogPath = true
 		}
 		if !foundLinePprofEnabled && strings.Contains(line, "pprofEnabled:") {
-			lines[i] = fmt.Sprintf(`pprofEnabled: %t`, c.Config.PprofEnabled)
+			lines[i] = fmt.Sprintf(`pprofEnabled: %t`, cfg.PprofEnabled)
 			foundLinePprofEnabled = true
 		}
 		if !foundLinePprofAddress && strings.Contains(line, "pprofAddress:") {
-			lines[i] = fmt.Sprintf(`pprofAddress: "%s"`, c.Config.PprofAddress)
+			lines[i] = fmt.Sprintf(`pprofAddress: "%s"`, cfg.PprofAddress)
 			foundLinePprofAddress = true
 		}
 	}
@@ -428,7 +469,7 @@ func (c *AppConfig) processLines(lines []string) []string {
 		lines = append(lines, "#")
 		lines = append(lines, `# Options: "ERROR", "DEBUG", "INFO", "WARN", "TRACE"`)
 		lines = append(lines, "#")
-		lines = append(lines, fmt.Sprintf(`logLevel: "%s"`, c.Config.LogLevel))
+		lines = append(lines, fmt.Sprintf(`logLevel: "%s"`, cfg.LogLevel))
 	}
 
 	if !foundLineLogPath {
@@ -436,10 +477,10 @@ func (c *AppConfig) processLines(lines []string) []string {
 		lines = append(lines, "#")
 		lines = append(lines, "# Optional")
 		lines = append(lines, "#")
-		if c.Config.LogPath == "" {
+		if cfg.LogPath == "" {
 			lines = append(lines, `#logPath: ""`)
 		} else {
-			lines = append(lines, fmt.Sprintf(`logPath: "%s"`, c.Config.LogPath))
+			lines = append(lines, fmt.Sprintf(`logPath: "%s"`, cfg.LogPath))
 		}
 	}
 
@@ -448,7 +489,7 @@ func (c *AppConfig) processLines(lines []string) []string {
 		lines = append(lines, "#")
 		lines = append(lines, "# Default: false")
 		lines = append(lines, "#")
-		lines = append(lines, fmt.Sprintf(`pprofEnabled: %t`, c.Config.PprofEnabled))
+		lines = append(lines, fmt.Sprintf(`pprofEnabled: %t`, cfg.PprofEnabled))
 	}
 
 	if !foundLinePprofAddress {
@@ -456,7 +497,7 @@ func (c *AppConfig) processLines(lines []string) []string {
 		lines = append(lines, "#")
 		lines = append(lines, `# Default: "127.0.0.1:6060"`)
 		lines = append(lines, "#")
-		lines = append(lines, fmt.Sprintf(`pprofAddress: "%s"`, c.Config.PprofAddress))
+		lines = append(lines, fmt.Sprintf(`pprofAddress: "%s"`, cfg.PprofAddress))
 	}
 
 	return lines

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,111 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"mangarr/internal/domain"
+	"mangarr/internal/logger"
+)
+
+func TestLoadRejectsInvalidCheckInterval(t *testing.T) {
+	dir := t.TempDir()
+	writeTestConfig(t, dir, `downloadLocation: "`+dir+`"
+checkInterval: 0
+`)
+
+	if _, err := Load(dir, "test"); err == nil {
+		t.Fatal("expected invalid check interval to fail")
+	}
+}
+
+func TestSnapshotDoesNotExposeMutableConfig(t *testing.T) {
+	dir := t.TempDir()
+	writeTestConfig(t, dir, `downloadLocation: "`+dir+`"
+checkInterval: 15
+monitoredManga:
+  One Piece:
+    source: tcbscans
+    manga: One Piece
+`)
+
+	cfg, err := Load(dir, "test")
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+
+	snapshot := cfg.Snapshot()
+	snapshot.MonitoredManga["One Piece"].Manga = "changed"
+	delete(snapshot.MonitoredManga, "One Piece")
+
+	got := cfg.Snapshot()
+	if got.MonitoredManga["One Piece"].Manga != "One Piece" {
+		t.Fatalf("stored config changed through snapshot: %#v", got.MonitoredManga)
+	}
+}
+
+func TestDynamicReloadPublishesValidatedSnapshot(t *testing.T) {
+	dir := t.TempDir()
+	writeTestConfig(t, dir, `downloadLocation: "`+dir+`"
+checkInterval: 15
+`)
+
+	cfg, err := Load(dir, "test")
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	snapshot := cfg.Snapshot()
+	reloads, err := cfg.DynamicReload(logger.New(&snapshot))
+	if err != nil {
+		t.Fatalf("watch config: %v", err)
+	}
+
+	writeTestConfig(t, dir, `downloadLocation: "`+dir+`"
+checkInterval: 2
+monitoredManga:
+  One Piece:
+    source: tcbscans
+    manga: One Piece
+`)
+
+	select {
+	case <-reloads:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for config reload")
+	}
+
+	got := cfg.Snapshot()
+	if got.CheckInterval != 2 {
+		t.Fatalf("check interval = %s, want 2", got.CheckInterval)
+	}
+	if got.MonitoredManga["One Piece"].Source != "tcbscans" {
+		t.Fatalf("monitored manga not reloaded: %#v", got.MonitoredManga)
+	}
+}
+
+func TestValidateRejectsNullMonitoredManga(t *testing.T) {
+	cfg := domain.Config{
+		DownloadLocation: "/tmp",
+		NamingTemplate:   "{manga:<.>}",
+		CheckInterval:    15,
+		LogLevel:         "INFO",
+		LogMaxSize:       50,
+		LogMaxBackups:    3,
+		MonitoredManga: map[string]*domain.MonitoredManga{
+			"Broken": nil,
+		},
+	}
+
+	if err := validate(cfg); err == nil {
+		t.Fatal("expected null monitored manga to fail")
+	}
+}
+
+func writeTestConfig(t *testing.T, dir, contents string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, "config.yaml"), []byte(contents), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+}

--- a/internal/domain/config.go
+++ b/internal/domain/config.go
@@ -12,7 +12,7 @@ type Config struct {
 	PprofAddress     string                     `yaml:"pprofAddress"`
 	MonitoredManga   map[string]*MonitoredManga `yaml:"monitoredManga"`
 	LogPath          string                     `yaml:"logPath"`
-	LogLevel         string                     `yaml:"LogLevel"`
+	LogLevel         string                     `yaml:"logLevel"`
 	LogMaxSize       int                        `yaml:"logMaxSize"` // in megabytes
 	LogMaxBackups    int                        `yaml:"logMaxBackups"`
 }


### PR DESCRIPTION
<!-- ship-stack:start -->
## PR stack

> [!NOTE]
> This PR is part of a stack. Merge it with the full stack when ready.

Depends on:
- #102

Followed by:
- #104
<!-- ship-stack:end -->

## Problem

Config reload mutates a shared map while monitor reads it. The monitor timer also captures the initial interval forever, invalid intervals can panic, and the first check waits for a full interval.

## Fix

- Load, validate, clone, and atomically publish immutable config snapshots.
- Reject invalid reloads while retaining the last valid snapshot.
- Reapply environment overrides on each reload.
- Run one monitor cycle immediately and reset the timer after interval changes.
- Use context-driven scheduling and bounded per-cycle groups for shutdown.
- Document reloadable and restart-only settings.

## Tests

- Added config validation and snapshot isolation coverage.
- Added file-watch reload coverage under the race detector.
- Covered null monitored entries and invalid intervals.
