### PR TITLE
refactor(cli): construct testable commands

### DIFF
--- a/cmd/download.go
+++ b/cmd/download.go
@@ -21,203 +21,205 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var downloadCmd = &cobra.Command{
-	Use:          "download",
-	Short:        "Download a specified chapter",
-	SilenceUsage: true,
-	RunE: func(cmd *cobra.Command, _ []string) error {
-		ctx := cmd.Context()
+func newDownloadCommand(options *downloadOptions) *cobra.Command {
+	return &cobra.Command{
+		Use:          "download",
+		Short:        "Download a specified chapter",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			ctx := cmd.Context()
 
-		// init new logger
-		log := zerolog.New(zerolog.ConsoleWriter{Out: os.Stderr, TimeFormat: time.RFC3339}).With().Timestamp().Logger()
+			// init new logger
+			log := zerolog.New(zerolog.ConsoleWriter{Out: os.Stderr, TimeFormat: time.RFC3339}).With().Timestamp().Logger()
 
-		if !cmd.Flags().Changed("first") && !cmd.Flags().Changed("chapters") && !cmd.Flags().Changed("all") {
-			latest = true
-		}
+			if !cmd.Flags().Changed("first") && !cmd.Flags().Changed("chapters") && !cmd.Flags().Changed("all") {
+				options.latest = true
+			}
 
-		if err := files.IsValidLocation(downloadDirectory); err != nil {
-			return fmt.Errorf("invalid download location: %w", err)
-		}
+			if err := files.IsValidLocation(options.downloadDirectory); err != nil {
+				return fmt.Errorf("invalid download location: %w", err)
+			}
 
-		var s domain.Source
+			var s domain.Source
 
-		switch mangaSource {
-		case "tcbscans":
-			s = source.NewTCBScans(manga)
-		case "mangadex":
-			s = source.NewMangadex(manga, group, language)
-		case "mangaplus":
-			s = source.NewMangaPlus(manga)
-		case "flamecomics":
-			s = source.NewFlamecomics(manga)
-		case "asurascans":
-			s = source.NewAsurascans(manga)
-		case "cubari":
-			s = source.NewCubari(manga, group)
-		case "weebcentral":
-			s = source.NewWeebCentral(manga)
-		case "comix":
-			s = source.NewComix(manga, group)
-		case "atsumaru":
-			s = source.NewAtsumaru(manga, group)
-		default:
-			return fmt.Errorf("invalid source %q", mangaSource)
-		}
+			switch options.mangaSource {
+			case "tcbscans":
+				s = source.NewTCBScans(options.manga)
+			case "mangadex":
+				s = source.NewMangadex(options.manga, options.group, options.language)
+			case "mangaplus":
+				s = source.NewMangaPlus(options.manga)
+			case "flamecomics":
+				s = source.NewFlamecomics(options.manga)
+			case "asurascans":
+				s = source.NewAsurascans(options.manga)
+			case "cubari":
+				s = source.NewCubari(options.manga, options.group)
+			case "weebcentral":
+				s = source.NewWeebCentral(options.manga)
+			case "comix":
+				s = source.NewComix(options.manga, options.group)
+			case "atsumaru":
+				s = source.NewAtsumaru(options.manga, options.group)
+			default:
+				return fmt.Errorf("invalid source %q", options.mangaSource)
+			}
 
-		if err := s.ValidateInput(); err != nil {
-			return fmt.Errorf("invalid input: %w", err)
-		}
+			if err := s.ValidateInput(); err != nil {
+				return fmt.Errorf("invalid input: %w", err)
+			}
 
-		selectedManga, err := s.GetManga(ctx)
-		if err != nil {
-			return fmt.Errorf("getting manga from %s: %w", s, err)
-		}
-
-		if err := s.GetChapters(ctx, selectedManga); err != nil {
-			return fmt.Errorf("getting chapters for %s: %w", selectedManga.Title, err)
-		}
-
-		var selectedChapterNumbers []domain.ChapterNumber
-
-		firstChapterNr, latestChapterNr, err := parse.MinMaxChapterNumbers(selectedManga.Chapters)
-		if err != nil {
-			return fmt.Errorf("parsing chapter numbers for %s: %w", selectedManga.Title, err)
-		}
-
-		switch {
-		case first:
-			selectedChapterNumbers = []domain.ChapterNumber{firstChapterNr}
-		case latest:
-			selectedChapterNumbers = []domain.ChapterNumber{latestChapterNr}
-		case downloadAll:
-			selectedChapterNumbers = sortedChapterNumbers(selectedManga.Chapters)
-		default:
-			selectedChapterNumbers, err = parse.ChapterSelection(chapterNumbers, selectedManga.Chapters)
+			selectedManga, err := s.GetManga(ctx)
 			if err != nil {
-				return fmt.Errorf("parsing chapter selection for %s: %w", selectedManga.Title, err)
+				return fmt.Errorf("getting manga from %s: %w", s, err)
 			}
-		}
 
-		if len(selectedChapterNumbers) == 0 {
-			return fmt.Errorf("finding matching chapters in range %s for %s", chapterNumbers, selectedManga.Title)
-		}
-
-		overwrittenTitle := sanitize.Filename(overwrite)
-		if len(overwrittenTitle) != 0 {
-			selectedManga.Title = overwrittenTitle
-		}
-
-		const (
-			chapterStatusDownloaded = "downloaded"
-			chapterStatusSkipped    = "skipped"
-			chapterStatusFailed     = "failed"
-		)
-
-		type chapterResult struct {
-			chapterNumber domain.ChapterNumber
-			status        string
-		}
-
-		results := make(chan chapterResult, len(selectedChapterNumbers))
-
-		// semaphore to limit concurrency to maxConcurrentChapterProcesses which is set to 10
-		sem := semaphore.NewWeighted(maxConcurrentChapterProcesses)
-		var wg sync.WaitGroup
-
-		for _, chapterNumber := range selectedChapterNumbers {
-			wg.Go(func() {
-				sem.Acquire()
-
-				result := chapterResult{
-					chapterNumber: chapterNumber,
-					status:        chapterStatusFailed,
-				}
-				shouldDelay := true
-
-				defer func() {
-					if shouldDelay {
-						time.Sleep(chapterDelay)
-					}
-
-					results <- result
-					sem.Release()
-				}()
-
-				selectedChapter, ok := selectedManga.Chapters[chapterNumber]
-				if !ok {
-					err := fmt.Errorf("chapter %s not found", chapterNumber)
-					log.Error().Err(err).Msgf("Failed to find chapter with number %s", chapterNumber)
-					return
-				}
-
-				t := templater.New(selectedManga, selectedChapter)
-				templatedName := t.ExecTemplate(naming)
-
-				chapterFolder := sanitize.Filename(templatedName)
-				contentPath := filepath.Join(downloadDirectory, selectedManga.Title, chapterFolder+".cbz")
-
-				if _, err := os.Stat(contentPath); err == nil {
-					log.Info().Msgf("Chapter has already been downloaded, skipping %q", templatedName)
-					result.status = chapterStatusSkipped
-					shouldDelay = false
-					return
-				}
-
-				if err := s.GetImageURLs(ctx, &selectedChapter); err != nil {
-					log.Error().Err(err).Msgf("Failed to get image URLs for chapter %s", selectedChapter.Number)
-					return
-				}
-
-				log.Info().Msgf("Downloading %q", templatedName)
-				if err := download.Chapter(ctx, log, contentPath, selectedChapter, selectedManga.IsManhwa, files.CreateCbzArchive); err != nil {
-					log.Error().Err(err).Msgf("Failed to download chapter %q", templatedName)
-					return
-				}
-
-				log.Info().Msgf("Finished downloading %q", templatedName)
-				result.status = chapterStatusDownloaded
-			})
-		}
-
-		wg.Wait()
-		close(results)
-
-		downloaded := 0
-		var skipped []domain.ChapterNumber
-		var failed []domain.ChapterNumber
-		for result := range results {
-			switch result.status {
-			case chapterStatusDownloaded:
-				downloaded++
-			case chapterStatusSkipped:
-				skipped = append(skipped, result.chapterNumber)
-			case chapterStatusFailed:
-				failed = append(failed, result.chapterNumber)
+			if err := s.GetChapters(ctx, selectedManga); err != nil {
+				return fmt.Errorf("getting chapters for %s: %w", selectedManga.Title, err)
 			}
-		}
 
-		if len(selectedChapterNumbers) > 1 {
-			log.Info().Msgf(
-				"Summary: downloaded=%d skipped=%d failed=%d",
-				downloaded,
-				len(skipped),
-				len(failed),
+			var selectedChapterNumbers []domain.ChapterNumber
+
+			firstChapterNr, latestChapterNr, err := parse.MinMaxChapterNumbers(selectedManga.Chapters)
+			if err != nil {
+				return fmt.Errorf("parsing chapter numbers for %s: %w", selectedManga.Title, err)
+			}
+
+			switch {
+			case options.first:
+				selectedChapterNumbers = []domain.ChapterNumber{firstChapterNr}
+			case options.latest:
+				selectedChapterNumbers = []domain.ChapterNumber{latestChapterNr}
+			case options.downloadAll:
+				selectedChapterNumbers = sortedChapterNumbers(selectedManga.Chapters)
+			default:
+				selectedChapterNumbers, err = parse.ChapterSelection(options.chapterNumbers, selectedManga.Chapters)
+				if err != nil {
+					return fmt.Errorf("parsing chapter selection for %s: %w", selectedManga.Title, err)
+				}
+			}
+
+			if len(selectedChapterNumbers) == 0 {
+				return fmt.Errorf("finding matching chapters in range %s for %s", options.chapterNumbers, selectedManga.Title)
+			}
+
+			overwrittenTitle := sanitize.Filename(options.overwrite)
+			if len(overwrittenTitle) != 0 {
+				selectedManga.Title = overwrittenTitle
+			}
+
+			const (
+				chapterStatusDownloaded = "downloaded"
+				chapterStatusSkipped    = "skipped"
+				chapterStatusFailed     = "failed"
 			)
 
-			if len(skipped) > 0 {
-				log.Info().Msgf("Skipped chapters: %s", parse.FormatChapterList(skipped))
+			type chapterResult struct {
+				chapterNumber domain.ChapterNumber
+				status        string
 			}
+
+			results := make(chan chapterResult, len(selectedChapterNumbers))
+
+			// semaphore to limit concurrency to maxConcurrentChapterProcesses which is set to 10
+			sem := semaphore.NewWeighted(maxConcurrentChapterProcesses)
+			var wg sync.WaitGroup
+
+			for _, chapterNumber := range selectedChapterNumbers {
+				wg.Go(func() {
+					sem.Acquire()
+
+					result := chapterResult{
+						chapterNumber: chapterNumber,
+						status:        chapterStatusFailed,
+					}
+					shouldDelay := true
+
+					defer func() {
+						if shouldDelay {
+							time.Sleep(chapterDelay)
+						}
+
+						results <- result
+						sem.Release()
+					}()
+
+					selectedChapter, ok := selectedManga.Chapters[chapterNumber]
+					if !ok {
+						err := fmt.Errorf("chapter %s not found", chapterNumber)
+						log.Error().Err(err).Msgf("Failed to find chapter with number %s", chapterNumber)
+						return
+					}
+
+					t := templater.New(selectedManga, selectedChapter)
+					templatedName := t.ExecTemplate(options.naming)
+
+					chapterFolder := sanitize.Filename(templatedName)
+					contentPath := filepath.Join(options.downloadDirectory, selectedManga.Title, chapterFolder+".cbz")
+
+					if _, err := os.Stat(contentPath); err == nil {
+						log.Info().Msgf("Chapter has already been downloaded, skipping %q", templatedName)
+						result.status = chapterStatusSkipped
+						shouldDelay = false
+						return
+					}
+
+					if err := s.GetImageURLs(ctx, &selectedChapter); err != nil {
+						log.Error().Err(err).Msgf("Failed to get image URLs for chapter %s", selectedChapter.Number)
+						return
+					}
+
+					log.Info().Msgf("Downloading %q", templatedName)
+					if err := download.Chapter(ctx, log, contentPath, selectedChapter, selectedManga.IsManhwa, files.CreateCbzArchive); err != nil {
+						log.Error().Err(err).Msgf("Failed to download chapter %q", templatedName)
+						return
+					}
+
+					log.Info().Msgf("Finished downloading %q", templatedName)
+					result.status = chapterStatusDownloaded
+				})
+			}
+
+			wg.Wait()
+			close(results)
+
+			downloaded := 0
+			var skipped []domain.ChapterNumber
+			var failed []domain.ChapterNumber
+			for result := range results {
+				switch result.status {
+				case chapterStatusDownloaded:
+					downloaded++
+				case chapterStatusSkipped:
+					skipped = append(skipped, result.chapterNumber)
+				case chapterStatusFailed:
+					failed = append(failed, result.chapterNumber)
+				}
+			}
+
+			if len(selectedChapterNumbers) > 1 {
+				log.Info().Msgf(
+					"Summary: downloaded=%d skipped=%d failed=%d",
+					downloaded,
+					len(skipped),
+					len(failed),
+				)
+
+				if len(skipped) > 0 {
+					log.Info().Msgf("Skipped chapters: %s", parse.FormatChapterList(skipped))
+				}
+				if len(failed) > 0 {
+					log.Info().Msgf("Failed chapters: %s", parse.FormatChapterList(failed))
+				}
+			}
+
 			if len(failed) > 0 {
-				log.Info().Msgf("Failed chapters: %s", parse.FormatChapterList(failed))
+				return fmt.Errorf("failed to download chapters: %s", parse.FormatChapterList(failed))
 			}
-		}
 
-		if len(failed) > 0 {
-			return fmt.Errorf("failed to download chapters: %s", parse.FormatChapterList(failed))
-		}
-
-		return nil
-	},
+			return nil
+		},
+	}
 }
 
 const chapterDelay = 2 * time.Second

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -1,30 +1,33 @@
 package cmd
 
+import "github.com/spf13/cobra"
+
 const (
 	maxConcurrentChapterProcesses = 10
 	maxConcurrentSourceProcesses  = 10
 )
 
-var (
-	configPath        string
+type rootOptions struct {
+	configPath string
+}
+
+type downloadOptions struct {
 	naming            string
 	downloadDirectory string
 	mangaSource       string
 	overwrite         string
+	manga             string
+	group             string
+	language          string
+	chapterNumbers    string
+	first             bool
+	latest            bool
+	downloadAll       bool
+}
 
-	manga    string
-	group    string
-	language string
-
-	chapterNumbers string
-	first          bool
-	latest         bool
-	downloadAll    bool
-)
-
-func initRootFlags() {
-	rootCmd.PersistentFlags().StringVarP(
-		&configPath,
+func initRootFlags(root *cobra.Command, options *rootOptions) {
+	root.PersistentFlags().StringVarP(
+		&options.configPath,
 		"config",
 		"c",
 		"",
@@ -32,95 +35,95 @@ func initRootFlags() {
 	)
 }
 
-func initDownloadFlags() {
-	downloadCmd.Flags().StringVarP(
-		&downloadDirectory,
+func initDownloadFlags(download *cobra.Command, options *downloadOptions) {
+	download.Flags().StringVarP(
+		&options.downloadDirectory,
 		"downloadDirectory",
 		"d",
 		"",
 		"specifies the directory where you want to save your downloads to",
 	)
-	downloadCmd.Flags().StringVarP(
-		&mangaSource,
+	download.Flags().StringVarP(
+		&options.mangaSource,
 		"source",
 		"s",
 		"",
 		"specifies the source of the manga",
 	)
-	downloadCmd.Flags().StringVarP(
-		&naming,
+	download.Flags().StringVarP(
+		&options.naming,
 		"naming",
 		"n",
 		"{manga:<.>} Ch. {num:3}{title: - <.>}",
 		"specifies the naming template you want to use for naming chapters",
 	)
-	downloadCmd.Flags().StringVarP(
-		&overwrite,
+	download.Flags().StringVarP(
+		&options.overwrite,
 		"overwrite",
 		"o",
 		"",
 		"overwrites the parsed manga name",
 	)
 
-	downloadCmd.Flags().StringVarP(
-		&manga,
+	download.Flags().StringVarP(
+		&options.manga,
 		"manga",
 		"m",
 		"",
 		"specifies the manga you want to download",
 	)
-	downloadCmd.Flags().StringVarP(
-		&group,
+	download.Flags().StringVarP(
+		&options.group,
 		"group",
 		"g",
 		"",
 		"specifies the group you want to download the chapter from",
 	)
-	downloadCmd.Flags().StringVarP(
-		&language,
+	download.Flags().StringVarP(
+		&options.language,
 		"language",
 		"l",
 		"en",
 		"specifies the language you want to download. default: en",
 	)
 
-	downloadCmd.Flags().StringVarP(
-		&chapterNumbers,
+	download.Flags().StringVarP(
+		&options.chapterNumbers,
 		"chapters",
 		"C",
 		"",
 		"specifies the chapter numbers you want to download",
 	)
-	downloadCmd.Flags().BoolVarP(
-		&first,
+	download.Flags().BoolVarP(
+		&options.first,
 		"first",
 		"1",
 		false,
 		"download the first chapter",
 	)
-	downloadCmd.Flags().BoolVarP(
-		&latest,
+	download.Flags().BoolVarP(
+		&options.latest,
 		"latest",
 		"L",
 		false,
 		"download the latest chapter",
 	)
-	downloadCmd.Flags().BoolVarP(
-		&downloadAll,
+	download.Flags().BoolVarP(
+		&options.downloadAll,
 		"all",
 		"A",
 		false,
 		"download all available chapters",
 	)
 
-	downloadCmd.MarkFlagsMutuallyExclusive("first", "chapters")
-	downloadCmd.MarkFlagsMutuallyExclusive("latest", "chapters")
-	downloadCmd.MarkFlagsMutuallyExclusive("first", "latest")
-	downloadCmd.MarkFlagsMutuallyExclusive("all", "chapters")
-	downloadCmd.MarkFlagsMutuallyExclusive("all", "first")
-	downloadCmd.MarkFlagsMutuallyExclusive("all", "latest")
+	download.MarkFlagsMutuallyExclusive("first", "chapters")
+	download.MarkFlagsMutuallyExclusive("latest", "chapters")
+	download.MarkFlagsMutuallyExclusive("first", "latest")
+	download.MarkFlagsMutuallyExclusive("all", "chapters")
+	download.MarkFlagsMutuallyExclusive("all", "first")
+	download.MarkFlagsMutuallyExclusive("all", "latest")
 
-	_ = downloadCmd.MarkFlagRequired("downloadDirectory")
-	_ = downloadCmd.MarkFlagRequired("source")
-	_ = downloadCmd.MarkFlagRequired("manga")
+	_ = download.MarkFlagRequired("downloadDirectory")
+	_ = download.MarkFlagRequired("source")
+	_ = download.MarkFlagRequired("manga")
 }

--- a/cmd/monitor.go
+++ b/cmd/monitor.go
@@ -25,72 +25,78 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-var monitorCmd = &cobra.Command{
-	Use:   "monitor",
-	Short: "Monitor a specified manga for new chapters",
-	Run: func(cmd *cobra.Command, _ []string) {
-		runCtx, stop := signal.NotifyContext(
-			cmd.Context(),
-			syscall.SIGHUP,
-			syscall.SIGINT,
-			syscall.SIGQUIT,
-			syscall.SIGTERM,
-		)
-		defer stop()
+func newMonitorCommand(options *rootOptions) *cobra.Command {
+	return &cobra.Command{
+		Use:          "monitor",
+		Short:        "Monitor a specified manga for new chapters",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			runCtx, stop := signal.NotifyContext(
+				cmd.Context(),
+				syscall.SIGHUP,
+				syscall.SIGINT,
+				syscall.SIGQUIT,
+				syscall.SIGTERM,
+			)
+			defer stop()
 
-		cfg := config.New(configPath, buildinfo.Version)
-		snapshot := cfg.Snapshot()
-
-		log := logger.New(&snapshot)
-
-		if err := cfg.UpdateConfig(); err != nil {
-			log.Error().Err(err).Msg("error updating config")
-		}
-
-		reloads, err := cfg.DynamicReload(log)
-		if err != nil {
-			log.Error().Err(err).Msg("dynamic config reload disabled")
-			reloads = make(chan struct{})
-		}
-
-		if err := files.IsValidLocation(snapshot.DownloadLocation); err != nil {
-			log.Fatal().Err(err).Msgf("invalid download location")
-		}
-
-		log.Info().Msg("Starting to monitor configured manga")
-		log.Info().Msgf("Version: %s", buildinfo.Version)
-		log.Info().Msgf("Commit: %s", buildinfo.Commit)
-		log.Info().Msgf("Build date: %s", buildinfo.Date)
-		log.Info().Msgf("Log-level: %s", snapshot.LogLevel)
-
-		if snapshot.PprofEnabled {
-			pprofAddress, err := perf.StartPprofServer(runCtx, log, snapshot.PprofAddress)
+			cfg, err := config.Load(options.configPath, buildinfo.Version)
 			if err != nil {
-				log.Error().Err(err).Msg("error starting pprof endpoint")
-			} else {
-				log.Info().Msgf("pprof endpoint available at http://%s/debug/pprof/", pprofAddress)
+				return fmt.Errorf("loading config: %w", err)
 			}
-		}
+			snapshot := cfg.Snapshot()
 
-		runMonitorCycle(runCtx, snapshot, log)
+			log := logger.New(&snapshot)
 
-		timer := time.NewTimer(snapshot.CheckInterval * time.Minute)
-		defer timer.Stop()
-		for {
-			select {
-			case <-runCtx.Done():
-				log.Info().Msg("stopping monitoring")
-				return
-			case <-reloads:
-				snapshot = cfg.Snapshot()
-				resetTimer(timer, snapshot.CheckInterval*time.Minute)
-			case <-timer.C:
-				snapshot = cfg.Snapshot()
-				runMonitorCycle(runCtx, snapshot, log)
-				timer.Reset(snapshot.CheckInterval * time.Minute)
+			if err := cfg.UpdateConfig(); err != nil {
+				log.Error().Err(err).Msg("error updating config")
 			}
-		}
-	},
+
+			reloads, err := cfg.DynamicReload(log)
+			if err != nil {
+				log.Error().Err(err).Msg("dynamic config reload disabled")
+				reloads = make(chan struct{})
+			}
+
+			if err := files.IsValidLocation(snapshot.DownloadLocation); err != nil {
+				return fmt.Errorf("invalid download location: %w", err)
+			}
+
+			log.Info().Msg("Starting to monitor configured manga")
+			log.Info().Msgf("Version: %s", buildinfo.Version)
+			log.Info().Msgf("Commit: %s", buildinfo.Commit)
+			log.Info().Msgf("Build date: %s", buildinfo.Date)
+			log.Info().Msgf("Log-level: %s", snapshot.LogLevel)
+
+			if snapshot.PprofEnabled {
+				pprofAddress, err := perf.StartPprofServer(runCtx, log, snapshot.PprofAddress)
+				if err != nil {
+					log.Error().Err(err).Msg("error starting pprof endpoint")
+				} else {
+					log.Info().Msgf("pprof endpoint available at http://%s/debug/pprof/", pprofAddress)
+				}
+			}
+
+			runMonitorCycle(runCtx, snapshot, log)
+
+			timer := time.NewTimer(snapshot.CheckInterval * time.Minute)
+			defer timer.Stop()
+			for {
+				select {
+				case <-runCtx.Done():
+					log.Info().Msg("stopping monitoring")
+					return nil
+				case <-reloads:
+					snapshot = cfg.Snapshot()
+					resetTimer(timer, snapshot.CheckInterval*time.Minute)
+				case <-timer.C:
+					snapshot = cfg.Snapshot()
+					runMonitorCycle(runCtx, snapshot, log)
+					timer.Reset(snapshot.CheckInterval * time.Minute)
+				}
+			}
+		},
+	}
 }
 
 func resetTimer(timer *time.Timer, duration time.Duration) {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,15 +1,37 @@
 package cmd
 
 import (
-	"os"
+	"net/http"
+	"time"
 
 	"github.com/spf13/cobra"
 )
 
-var rootCmd = &cobra.Command{
-	Use:   "mangarr",
-	Short: "Download and monitor manga chapters from various providers.",
-	Long: `Download and monitor manga chapters from various providers.
+type dependencies struct {
+	versionClient *http.Client
+	releaseURL    string
+}
+
+func defaultDependencies() dependencies {
+	return dependencies{
+		versionClient: &http.Client{Timeout: 10 * time.Second},
+		releaseURL:    githubURL,
+	}
+}
+
+func NewRootCommand() *cobra.Command {
+	return newRootCommand(defaultDependencies())
+}
+
+func newRootCommand(deps dependencies) *cobra.Command {
+	rootOptions := &rootOptions{}
+	downloadOptions := &downloadOptions{}
+
+	root := &cobra.Command{
+		Use:           "mangarr",
+		Short:         "Download and monitor manga chapters from various providers.",
+		SilenceErrors: true,
+		Long: `Download and monitor manga chapters from various providers.
 
 Provide a configuration file using one of the following methods:
 1. Use the --config <path> or -c <path> flag.
@@ -18,20 +40,18 @@ Provide a configuration file using one of the following methods:
 4. Place a config.yaml file in the directory of the binary.
 
 For more information and examples, visit https://github.com/nuxencs/mangarr`,
-}
-
-func init() {
-	initRootFlags()
-	initDownloadFlags()
-
-	rootCmd.AddCommand(versionCmd)
-	rootCmd.AddCommand(downloadCmd)
-	rootCmd.AddCommand(monitorCmd)
-}
-
-func Execute() {
-	err := rootCmd.Execute()
-	if err != nil {
-		os.Exit(1)
 	}
+
+	initRootFlags(root, rootOptions)
+	download := newDownloadCommand(downloadOptions)
+	initDownloadFlags(download, downloadOptions)
+	root.AddCommand(newVersionCommand(deps.versionClient, deps.releaseURL))
+	root.AddCommand(download)
+	root.AddCommand(newMonitorCommand(rootOptions))
+
+	return root
+}
+
+func Execute() error {
+	return NewRootCommand().Execute()
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,0 +1,68 @@
+package cmd
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestVersionSucceedsWhenUpdateCheckFails(t *testing.T) {
+	client := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return nil, errors.New("offline")
+	})}
+	root := newRootCommand(dependencies{
+		versionClient: client,
+		releaseURL:    githubURL,
+	})
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&stderr)
+	root.SetArgs([]string{"version"})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute version: %v", err)
+	}
+	if !strings.Contains(stdout.String(), "Version:") {
+		t.Fatalf("version output = %q", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "Update check unavailable:") || !strings.Contains(stderr.String(), "offline") {
+		t.Fatalf("update warning = %q", stderr.String())
+	}
+}
+
+func TestMonitorReturnsConfigError(t *testing.T) {
+	root := newRootCommand(defaultDependencies())
+	root.SetArgs([]string{"monitor", "--config", t.TempDir()})
+
+	if err := root.Execute(); err == nil {
+		t.Fatal("expected invalid generated config to fail")
+	}
+}
+
+func TestRootCommandsDoNotShareFlagState(t *testing.T) {
+	first := newRootCommand(defaultDependencies())
+	first.SetOut(io.Discard)
+	first.SetArgs([]string{"download", "--help"})
+	if err := first.Execute(); err != nil {
+		t.Fatalf("execute first root: %v", err)
+	}
+
+	second := newRootCommand(defaultDependencies())
+	flag := second.PersistentFlags().Lookup("config")
+	if flag == nil {
+		t.Fatal("second root has no config flag")
+	}
+	if flag.Changed {
+		t.Fatal("second root inherited changed flag state")
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return f(request)
+}

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -4,70 +4,71 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"os"
 	"time"
 
 	"mangarr/internal/buildinfo"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
 const githubURL = "https://api.github.com/repos/nuxencs/mangarr/releases/latest"
 
-// versionCmd represents the version command
-var versionCmd = &cobra.Command{
-	Use:   "version",
-	Short: "Display version info",
-	Run: func(cmd *cobra.Command, _ []string) {
-		ctx := cmd.Context()
+func newVersionCommand(client *http.Client, releaseURL string) *cobra.Command {
+	return &cobra.Command{
+		Use:   "version",
+		Short: "Display version info",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			fmt.Fprintln(cmd.OutOrStdout(), "Version:", buildinfo.Version)
+			fmt.Fprintln(cmd.OutOrStdout(), "Commit:", buildinfo.Commit)
+			fmt.Fprintln(cmd.OutOrStdout(), "Build date:", buildinfo.Date)
 
-		fmt.Println("Version:", buildinfo.Version)
-		fmt.Println("Commit:", buildinfo.Commit)
-		fmt.Println("Build date:", buildinfo.Date)
-
-		req, err := http.NewRequestWithContext(ctx, http.MethodGet, githubURL, nil)
-		if err != nil {
-			fmt.Println("Failed to create request:", err)
-			os.Exit(1)
-		}
-
-		// get the latest release tag from api
-		client := http.Client{
-			Timeout: 10 * time.Second,
-		}
-
-		resp, err := client.Do(req)
-		if err != nil {
-			if errors.Is(err, http.ErrHandlerTimeout) {
-				fmt.Println("Server timed out while fetching latest release from api")
-			} else {
-				fmt.Println("Failed to fetch latest release from api:", err)
+			release, err := latestRelease(cmd, client, releaseURL)
+			if err != nil {
+				fmt.Fprintln(cmd.ErrOrStderr(), "Update check unavailable:", err)
+				return nil
 			}
-			os.Exit(1)
-		}
-		defer resp.Body.Close()
+			if release.TagName != buildinfo.Version && buildinfo.Version != "dev" {
+				fmt.Fprintln(cmd.OutOrStdout())
+				fmt.Fprintln(cmd.OutOrStdout(), "Update available:", buildinfo.Version, "->", release.TagName)
+				fmt.Fprintln(cmd.OutOrStdout(), "Published at:", release.PublishedAt.Format(time.RFC3339))
+			}
 
-		// api returns 500 instead of 404 here
-		if resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusInternalServerError {
-			fmt.Println("No release found")
-			os.Exit(1)
-		}
+			return nil
+		},
+	}
+}
 
-		var rel struct {
-			TagName     string    `json:"tag_name"`
-			PublishedAt time.Time `json:"published_at"`
-		}
+type releaseInfo struct {
+	TagName     string    `json:"tag_name"`
+	PublishedAt time.Time `json:"published_at"`
+}
 
-		if err := json.NewDecoder(resp.Body).Decode(&rel); err != nil {
-			fmt.Println("Failed to decode response from api:", err)
-			os.Exit(1)
-		}
+func latestRelease(cmd *cobra.Command, client *http.Client, releaseURL string) (releaseInfo, error) {
+	req, err := http.NewRequestWithContext(cmd.Context(), http.MethodGet, releaseURL, nil)
+	if err != nil {
+		return releaseInfo{}, fmt.Errorf("creating request: %w", err)
+	}
 
-		if rel.TagName != buildinfo.Version && buildinfo.Version != "dev" {
-			fmt.Println()
-			fmt.Println("Update available:", buildinfo.Version, "->", rel.TagName)
-			fmt.Println("Published at:", rel.PublishedAt.Format(time.RFC3339))
-		}
-	},
+	resp, err := client.Do(req)
+	if err != nil {
+		return releaseInfo{}, fmt.Errorf("fetching latest release: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return releaseInfo{}, fmt.Errorf("no published release")
+	}
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return releaseInfo{}, fmt.Errorf("fetching latest release: status code %d", resp.StatusCode)
+	}
+
+	var release releaseInfo
+	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
+		return releaseInfo{}, fmt.Errorf("decoding latest release: %w", err)
+	}
+	if release.TagName == "" {
+		return releaseInfo{}, fmt.Errorf("latest release response has no tag")
+	}
+
+	return release, nil
 }

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -134,7 +134,8 @@ each reload. Changes to pprof and log file output settings require a restart.
 
 ### `version`
 
-Show local build/version info.
+Show local build/version info and attempt an advisory update check. Local version
+output succeeds when GitHub is unavailable.
 
 ```bash
 mangarr version

--- a/docs/exec-plans/active/2026-08-07-codebase-reliability-stack.md
+++ b/docs/exec-plans/active/2026-08-07-codebase-reliability-stack.md
@@ -122,3 +122,15 @@ and confirmed pagination, validation, and shutdown defects fail safely.
 
 Notes/risks: Fixtures detect parser drift after a captured response is updated.
 They do not replace scheduled live-source smoke checks.
+
+## Bucket 5 - Command seam - ALIGNED
+
+Built: Each execution now constructs a fresh Cobra tree, commands return errors
+to `main`, config setup is nonfatal, and the injected version client treats update
+lookup as advisory.
+
+Serves goal/decision because: User-facing command outcomes are testable without
+subprocess exits or live GitHub access, and local version reporting works offline.
+
+Notes/risks: Monitor source work still uses concrete production adapters. The
+next source and acquisition buckets add the remaining command test seams.

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/knadh/koanf/providers/file v1.2.1
 	github.com/knadh/koanf/providers/structs v1.0.0
 	github.com/knadh/koanf/v2 v2.3.5
-	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.35.1
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
@@ -45,6 +44,7 @@ require (
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/nlnwa/whatwg-url v0.6.2 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/saintfish/chardet v0.0.0-20230101081208-5e3ef4b5456d // indirect
 	github.com/spf13/pflag v1.0.9 // indirect

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -203,15 +203,6 @@ type AppConfig struct {
 	version    string
 }
 
-func New(configPath string, version string) *AppConfig {
-	c, err := Load(configPath, version)
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	return c
-}
-
 func Load(configPath string, version string) (*AppConfig, error) {
 	configFile, err := resolveConfigFile(configPath)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -1,7 +1,15 @@
 package main
 
-import "mangarr/cmd"
+import (
+	"fmt"
+	"os"
+
+	"mangarr/cmd"
+)
 
 func main() {
-	cmd.Execute()
+	if err := cmd.Execute(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
 }


### PR DESCRIPTION
<!-- ship-stack:start -->
## PR stack

> [!NOTE]
> This PR is part of a stack. Merge it with the full stack when ready.

Depends on:
- #104

Followed by:
- #106
<!-- ship-stack:end -->

## Why

Global Cobra commands retain flag state, command implementations exit the process, and version reporting depends on live GitHub access. These interfaces prevent direct command testing and make local version inspection unreliable offline.

## What changed

- Construct a fresh root command and option set for every execution.
- Return command and config errors to `main`, which owns process exit.
- Inject the version HTTP client and treat update lookup as advisory.
- Make monitor setup return actionable errors.
- Document offline version behavior.

## Tests

- Added offline version behavior coverage.
- Added direct monitor config failure coverage.
- Added repeated command-construction coverage for isolated flag state.
