### PR TITLE
refactor(source): simplify adapter interface

### DIFF
--- a/cmd/download.go
+++ b/cmd/download.go
@@ -40,42 +40,23 @@ func newDownloadCommand(options *downloadOptions) *cobra.Command {
 				return fmt.Errorf("invalid download location: %w", err)
 			}
 
-			var s domain.Source
-
-			switch options.mangaSource {
-			case "tcbscans":
-				s = source.NewTCBScans(options.manga)
-			case "mangadex":
-				s = source.NewMangadex(options.manga, options.group, options.language)
-			case "mangaplus":
-				s = source.NewMangaPlus(options.manga)
-			case "flamecomics":
-				s = source.NewFlamecomics(options.manga)
-			case "asurascans":
-				s = source.NewAsurascans(options.manga)
-			case "cubari":
-				s = source.NewCubari(options.manga, options.group)
-			case "weebcentral":
-				s = source.NewWeebCentral(options.manga)
-			case "comix":
-				s = source.NewComix(options.manga, options.group)
-			case "atsumaru":
-				s = source.NewAtsumaru(options.manga, options.group)
-			default:
-				return fmt.Errorf("invalid source %q", options.mangaSource)
+			s, err := source.Select(domain.MonitoredManga{
+				Source:   options.mangaSource,
+				Manga:    options.manga,
+				Group:    options.group,
+				Language: options.language,
+			})
+			if err != nil {
+				return fmt.Errorf("selecting source: %w", err)
 			}
 
 			if err := s.ValidateInput(); err != nil {
 				return fmt.Errorf("invalid input: %w", err)
 			}
 
-			selectedManga, err := s.GetManga(ctx)
+			selectedManga, err := s.Discover(ctx)
 			if err != nil {
 				return fmt.Errorf("getting manga from %s: %w", s, err)
-			}
-
-			if err := s.GetChapters(ctx, selectedManga); err != nil {
-				return fmt.Errorf("getting chapters for %s: %w", selectedManga.Title, err)
 			}
 
 			var selectedChapterNumbers []domain.ChapterNumber
@@ -164,10 +145,12 @@ func newDownloadCommand(options *downloadOptions) *cobra.Command {
 						return
 					}
 
-					if err := s.GetImageURLs(ctx, &selectedChapter); err != nil {
+					pages, err := s.Pages(ctx, selectedChapter)
+					if err != nil {
 						log.Error().Err(err).Msgf("Failed to get image URLs for chapter %s", selectedChapter.Number)
 						return
 					}
+					selectedChapter.ImageInfo = pages
 
 					log.Info().Msgf("Downloading %q", templatedName)
 					if err := download.Chapter(ctx, log, contentPath, selectedChapter, selectedManga.IsManhwa, files.CreateCbzArchive); err != nil {

--- a/cmd/monitor.go
+++ b/cmd/monitor.go
@@ -139,12 +139,9 @@ func monitorManga(ctx context.Context, cfg domain.Config, mangaTitle string, mon
 		return fmt.Errorf("validating input: %w", err)
 	}
 
-	selectedManga, err := mangaSource.GetManga(ctx)
+	selectedManga, err := mangaSource.Discover(ctx)
 	if err != nil {
 		return fmt.Errorf("getting manga from %s: %w", monitoredManga.Source, err)
-	}
-	if err := mangaSource.GetChapters(ctx, selectedManga); err != nil {
-		return fmt.Errorf("getting manga chapters: %w", err)
 	}
 
 	_, latestChapterNr, err := parse.MinMaxChapterNumbers(selectedManga.Chapters)
@@ -169,9 +166,11 @@ func monitorManga(ctx context.Context, cfg domain.Config, mangaTitle string, mon
 		return nil
 	}
 
-	if err := mangaSource.GetImageURLs(ctx, &selectedChapter); err != nil {
+	pages, err := mangaSource.Pages(ctx, selectedChapter)
+	if err != nil {
 		return fmt.Errorf("getting image URLs for chapter %s: %w", selectedChapter.Number, err)
 	}
+	selectedChapter.ImageInfo = pages
 
 	mLog.Info().Msgf("downloading %q", templatedName)
 	if err := download.Chapter(ctx, mLog, contentPath, selectedChapter, selectedManga.IsManhwa, files.CreateCbzArchive); err != nil {

--- a/docs/design-docs/source-adapters.md
+++ b/docs/design-docs/source-adapters.md
@@ -2,7 +2,12 @@
 
 Verified against `internal/source/` on 2026-08-07.
 
-All adapters implement `domain.Source`.
+All adapters implement the small `domain.Source` contract:
+
+- `Discover` returns manga metadata and its chapter map.
+- `Pages` returns an ordered page transport description for one chapter.
+- adapters return values. They do not mutate caller-owned manga or chapter values.
+- `source.Select` is the single registry used by download and monitor commands.
 
 ## Matrix
 
@@ -23,7 +28,7 @@ All adapters implement `domain.Source`.
 - validate early
 - keep selectors and parsing local to the adapter
 - prefer stable attributes or embedded data over brittle DOM traversal
-- reuse `internal/sharedhttp/` and `internal/browser/` before adding new transport helpers
+- reuse `internal/sharedhttp/` before adding new transport helpers
 - when an adapter drifts, add a regression test around the parsing seam if practical
 
 ## Shared Behavior

--- a/docs/exec-plans/active/2026-08-07-codebase-reliability-stack.md
+++ b/docs/exec-plans/active/2026-08-07-codebase-reliability-stack.md
@@ -134,3 +134,16 @@ subprocess exits or live GitHub access, and local version reporting works offlin
 
 Notes/risks: Monitor source work still uses concrete production adapters. The
 next source and acquisition buckets add the remaining command test seams.
+
+## Bucket 6 - Source interface and registry - ALIGNED
+
+Built: Replaced the mutation-based source lifecycle with `Discover` and `Pages`
+return values. Both command paths now construct adapters through one tested source
+registry.
+
+Serves goal/decision because: Every adapter now implements the same useful
+operations without no-op methods, and source selection cannot drift between
+download and monitor.
+
+Notes/risks: Discovery still retrieves the full chapter list because both current
+command flows need it. The next bucket centralizes the shared per-chapter work.

--- a/internal/domain/source.go
+++ b/internal/domain/source.go
@@ -9,9 +9,8 @@ import (
 type Source interface {
 	String() string
 	ValidateInput() error
-	GetManga(context.Context) (Manga, error)
-	GetChapters(context.Context, Manga) error
-	GetImageURLs(context.Context, *Chapter) error
+	Discover(context.Context) (Manga, error)
+	Pages(context.Context, Chapter) ([]ImageInfo, error)
 }
 
 type Manga struct {

--- a/internal/source/asurascans.go
+++ b/internal/source/asurascans.go
@@ -78,7 +78,7 @@ func (a *asurascans) ValidateInput() error {
 	return nil
 }
 
-func (a *asurascans) GetManga(ctx context.Context) (domain.Manga, error) {
+func (a *asurascans) Discover(ctx context.Context) (domain.Manga, error) {
 	parsed, err := url.Parse(a.MangaURL)
 	if err != nil {
 		return domain.Manga{}, fmt.Errorf("parsing URL %s: %w", a.MangaURL, err)
@@ -175,20 +175,16 @@ func (a *asurascans) GetManga(ctx context.Context) (domain.Manga, error) {
 	return manga, nil
 }
 
-func (a *asurascans) GetChapters(_ context.Context, _ domain.Manga) error {
-	return nil
-}
-
-func (a *asurascans) GetImageURLs(ctx context.Context, chapter *domain.Chapter) error {
+func (a *asurascans) Pages(ctx context.Context, chapter domain.Chapter) ([]domain.ImageInfo, error) {
 	body, err := a.fetch(ctx, chapter.URL)
 	if err != nil {
-		return fmt.Errorf("fetching chapter page %s: %w", chapter.URL, err)
+		return nil, fmt.Errorf("fetching chapter page %s: %w", chapter.URL, err)
 	}
 
 	matches := asurascansChapterAssetPattern.FindAllString(string(body), -1)
 	imageURLs := dedupeStrings(matches)
 	if len(imageURLs) == 0 {
-		return fmt.Errorf("getting image URLs for chapter %s", chapter.Number)
+		return nil, fmt.Errorf("getting image URLs for chapter %s", chapter.Number)
 	}
 
 	imageInfos := make([]domain.ImageInfo, 0, len(imageURLs))
@@ -196,8 +192,7 @@ func (a *asurascans) GetImageURLs(ctx context.Context, chapter *domain.Chapter) 
 		imageInfos = append(imageInfos, domain.ImageInfo{ImageURL: imageURL})
 	}
 
-	chapter.ImageInfo = imageInfos
-	return nil
+	return imageInfos, nil
 }
 
 func (a *asurascans) fetch(ctx context.Context, rawURL string) ([]byte, error) {

--- a/internal/source/asurascans_test.go
+++ b/internal/source/asurascans_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestAsurascansGetMangaParsesCurrentSeriesURL(t *testing.T) {
+func TestAsurascansDiscoverParsesCurrentSeriesURL(t *testing.T) {
 	t.Parallel()
 
 	const (
@@ -53,7 +53,7 @@ func TestAsurascansGetMangaParsesCurrentSeriesURL(t *testing.T) {
 
 	src := newTestAsurascans(server.URL+currentSeries, server.URL)
 
-	manga, err := src.GetManga(t.Context())
+	manga, err := src.Discover(t.Context())
 	require.NoError(t, err)
 	require.Equal(t, "Solo Max-Level Newbie", manga.Title)
 	require.Equal(t, server.URL+currentSeries, manga.URL)
@@ -70,7 +70,7 @@ func TestAsurascansGetMangaParsesCurrentSeriesURL(t *testing.T) {
 	require.Equal(t, server.URL+currentChapter2, ch248.URL)
 }
 
-func TestAsurascansGetMangaSkipsLockedChapters(t *testing.T) {
+func TestAsurascansDiscoverSkipsLockedChapters(t *testing.T) {
 	t.Parallel()
 
 	const (
@@ -109,7 +109,7 @@ func TestAsurascansGetMangaSkipsLockedChapters(t *testing.T) {
 
 	src := newTestAsurascans(server.URL+currentSeries, server.URL)
 
-	manga, err := src.GetManga(t.Context())
+	manga, err := src.Discover(t.Context())
 	require.NoError(t, err)
 	require.Equal(t, "Pick Me Up, Infinite Gacha", manga.Title)
 	require.Len(t, manga.Chapters, 1)
@@ -122,7 +122,7 @@ func TestAsurascansGetMangaSkipsLockedChapters(t *testing.T) {
 	require.Equal(t, "Regular Title", ch193.Title)
 }
 
-func TestAsurascansGetImageURLsExtractsChapterAssets(t *testing.T) {
+func TestAsurascansPagesExtractsChapterAssets(t *testing.T) {
 	t.Parallel()
 
 	const chapterPath = "/comics/solo-max-level-newbie-7f873ca6/chapter/249"
@@ -158,11 +158,11 @@ func TestAsurascansGetImageURLsExtractsChapterAssets(t *testing.T) {
 		Number: domain.MustParseChapterNumber("249"),
 	}
 
-	err := src.GetImageURLs(t.Context(), &chapter)
+	pages, err := src.Pages(t.Context(), chapter)
 	require.NoError(t, err)
-	require.Len(t, chapter.ImageInfo, 2)
-	require.Equal(t, "https://cdn.asurascans.com/asura-images/chapters/solo-max-level-newbie/249/001.webp", chapter.ImageInfo[0].ImageURL)
-	require.Equal(t, "https://cdn.asurascans.com/asura-images/chapters/solo-max-level-newbie/249/002.webp", chapter.ImageInfo[1].ImageURL)
+	require.Len(t, pages, 2)
+	require.Equal(t, "https://cdn.asurascans.com/asura-images/chapters/solo-max-level-newbie/249/001.webp", pages[0].ImageURL)
+	require.Equal(t, "https://cdn.asurascans.com/asura-images/chapters/solo-max-level-newbie/249/002.webp", pages[1].ImageURL)
 }
 
 func newTestAsurascans(mangaURL, baseURL string) *asurascans {

--- a/internal/source/atsumaru.go
+++ b/internal/source/atsumaru.go
@@ -94,7 +94,7 @@ func (a *atsumaru) ValidateInput() error {
 	return nil
 }
 
-func (a *atsumaru) GetManga(ctx context.Context) (domain.Manga, error) {
+func (a *atsumaru) Discover(ctx context.Context) (domain.Manga, error) {
 	mangaID, err := a.extractMangaID()
 	if err != nil {
 		return domain.Manga{}, err
@@ -144,14 +144,10 @@ func (a *atsumaru) GetManga(ctx context.Context) (domain.Manga, error) {
 	return manga, nil
 }
 
-func (a *atsumaru) GetChapters(_ context.Context, _ domain.Manga) error {
-	return nil
-}
-
-func (a *atsumaru) GetImageURLs(ctx context.Context, chapter *domain.Chapter) error {
+func (a *atsumaru) Pages(ctx context.Context, chapter domain.Chapter) ([]domain.ImageInfo, error) {
 	mangaID, err := a.extractMangaID()
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	apiURL, err := a.apiURL("api/read/chapter", url.Values{
@@ -159,30 +155,29 @@ func (a *atsumaru) GetImageURLs(ctx context.Context, chapter *domain.Chapter) er
 		"chapterId": []string{chapter.ID},
 	})
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	var chapterResp atsumaruReadChapterResponse
 	if err := a.getJSON(ctx, apiURL, &chapterResp); err != nil {
-		return fmt.Errorf("getting chapter pages from %s: %w", apiURL, err)
+		return nil, fmt.Errorf("getting chapter pages from %s: %w", apiURL, err)
 	}
 
 	imageInfos := make([]domain.ImageInfo, 0, len(chapterResp.ReadChapter.Pages))
 	for _, page := range chapterResp.ReadChapter.Pages {
 		imageURL, err := a.resolveImageURL(page.Image)
 		if err != nil {
-			return fmt.Errorf("resolving image URL %s: %w", page.Image, err)
+			return nil, fmt.Errorf("resolving image URL %s: %w", page.Image, err)
 		}
 
 		imageInfos = append(imageInfos, domain.ImageInfo{ImageURL: imageURL})
 	}
 
 	if len(imageInfos) == 0 {
-		return fmt.Errorf("getting image URLs for chapter ID %s", chapter.ID)
+		return nil, fmt.Errorf("getting image URLs for chapter ID %s", chapter.ID)
 	}
 
-	chapter.ImageInfo = imageInfos
-	return nil
+	return imageInfos, nil
 }
 
 func (a *atsumaru) extractMangaID() (string, error) {

--- a/internal/source/atsumaru_test.go
+++ b/internal/source/atsumaru_test.go
@@ -72,7 +72,7 @@ func TestAtsumaruValidateInputRequiresScanID(t *testing.T) {
 	require.EqualError(t, err, "atsumaru scan ID is required")
 }
 
-func TestAtsumaruGetManga(t *testing.T) {
+func TestAtsumaruDiscover(t *testing.T) {
 	t.Parallel()
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -94,7 +94,7 @@ func TestAtsumaruGetManga(t *testing.T) {
 
 	src := newTestAtsumaru(server.URL + "/manga/Q5Mqy")
 
-	manga, err := src.GetManga(t.Context())
+	manga, err := src.Discover(t.Context())
 	require.NoError(t, err)
 	require.Equal(t, "Q5Mqy", manga.ID)
 	require.Equal(t, server.URL+"/manga/Q5Mqy", manga.URL)
@@ -113,7 +113,7 @@ func TestAtsumaruGetManga(t *testing.T) {
 	require.Equal(t, "Chapter 7.1", ch71.Title)
 }
 
-func TestAtsumaruGetMangaErrorsWhenScanIDHasNoChapters(t *testing.T) {
+func TestAtsumaruDiscoverErrorsWhenScanIDHasNoChapters(t *testing.T) {
 	t.Parallel()
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -129,11 +129,11 @@ func TestAtsumaruGetMangaErrorsWhenScanIDHasNoChapters(t *testing.T) {
 
 	src := newTestAtsumaru(server.URL + "/manga/Q5Mqy")
 
-	_, err := src.GetManga(t.Context())
+	_, err := src.Discover(t.Context())
 	require.EqualError(t, err, "getting chapters for manga Kagurabachi")
 }
 
-func TestAtsumaruGetMangaErrorsWhenNoChapters(t *testing.T) {
+func TestAtsumaruDiscoverErrorsWhenNoChapters(t *testing.T) {
 	t.Parallel()
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -143,11 +143,11 @@ func TestAtsumaruGetMangaErrorsWhenNoChapters(t *testing.T) {
 
 	src := newTestAtsumaru(server.URL + "/manga/Q5Mqy")
 
-	_, err := src.GetManga(t.Context())
+	_, err := src.Discover(t.Context())
 	require.EqualError(t, err, "getting chapters for manga Kagurabachi")
 }
 
-func TestAtsumaruGetImageURLs(t *testing.T) {
+func TestAtsumaruPages(t *testing.T) {
 	t.Parallel()
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -174,14 +174,14 @@ func TestAtsumaruGetImageURLs(t *testing.T) {
 		Number: domain.MustParseChapterNumber("121"),
 	}
 
-	err := src.GetImageURLs(t.Context(), &chapter)
+	pages, err := src.Pages(t.Context(), chapter)
 	require.NoError(t, err)
-	require.Len(t, chapter.ImageInfo, 2)
-	require.Equal(t, server.URL+"/static/pages/yzmwX4/0.webp", chapter.ImageInfo[0].ImageURL)
-	require.Equal(t, "https://cdn.atsu.test/static/pages/yzmwX4/1.webp", chapter.ImageInfo[1].ImageURL)
+	require.Len(t, pages, 2)
+	require.Equal(t, server.URL+"/static/pages/yzmwX4/0.webp", pages[0].ImageURL)
+	require.Equal(t, "https://cdn.atsu.test/static/pages/yzmwX4/1.webp", pages[1].ImageURL)
 }
 
-func TestAtsumaruGetImageURLsErrorsWhenNoPages(t *testing.T) {
+func TestAtsumaruPagesErrorsWhenNoPages(t *testing.T) {
 	t.Parallel()
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -195,7 +195,7 @@ func TestAtsumaruGetImageURLsErrorsWhenNoPages(t *testing.T) {
 		Number: domain.MustParseChapterNumber("121"),
 	}
 
-	err := src.GetImageURLs(t.Context(), &chapter)
+	_, err := src.Pages(t.Context(), chapter)
 	require.EqualError(t, err, "getting image URLs for chapter ID yzmwX4")
 }
 

--- a/internal/source/comix.go
+++ b/internal/source/comix.go
@@ -128,7 +128,19 @@ func (c *comix) ValidateInput() error {
 	return nil
 }
 
-func (c *comix) GetManga(ctx context.Context) (domain.Manga, error) {
+func (c *comix) Discover(ctx context.Context) (domain.Manga, error) {
+	manga, err := c.getManga(ctx)
+	if err != nil {
+		return domain.Manga{}, err
+	}
+	if err := c.getChapters(ctx, manga); err != nil {
+		return domain.Manga{}, err
+	}
+
+	return manga, nil
+}
+
+func (c *comix) getManga(ctx context.Context) (domain.Manga, error) {
 	mangaID, err := c.extractIDFromURL(c.MangaURL)
 	if err != nil {
 		return domain.Manga{}, fmt.Errorf("extracting Comix ID from URL %s: %w", c.MangaURL, err)
@@ -151,7 +163,7 @@ func (c *comix) GetManga(ctx context.Context) (domain.Manga, error) {
 	}, nil
 }
 
-func (c *comix) GetChapters(ctx context.Context, manga domain.Manga) error {
+func (c *comix) getChapters(ctx context.Context, manga domain.Manga) error {
 	if manga.ID == "" {
 		return fmt.Errorf("getting Comix chapters: manga ID is empty")
 	}
@@ -205,24 +217,24 @@ func (c *comix) GetChapters(ctx context.Context, manga domain.Manga) error {
 	return nil
 }
 
-func (c *comix) GetImageURLs(ctx context.Context, chapter *domain.Chapter) error {
-	if chapter == nil || chapter.ID == "" {
-		return fmt.Errorf("getting Comix image URLs: chapter ID is empty")
+func (c *comix) Pages(ctx context.Context, chapter domain.Chapter) ([]domain.ImageInfo, error) {
+	if chapter.ID == "" {
+		return nil, fmt.Errorf("getting Comix image URLs: chapter ID is empty")
 	}
 
 	var response comixChapterDetail
 	if err := c.get(ctx, comixAPIPath+"/chapters/"+url.PathEscape(chapter.ID), nil, &response); err != nil {
-		return fmt.Errorf("getting Comix image URLs for chapter %s: %w", chapter.ID, err)
+		return nil, fmt.Errorf("getting Comix image URLs for chapter %s: %w", chapter.ID, err)
 	}
 	if len(response.Pages.Items) == 0 {
-		return fmt.Errorf("getting Comix image URLs for chapter %s: response has no pages", chapter.ID)
+		return nil, fmt.Errorf("getting Comix image URLs for chapter %s: response has no pages", chapter.ID)
 	}
 
 	imageInfos := make([]domain.ImageInfo, 0, len(response.Pages.Items))
 	for i, image := range response.Pages.Items {
 		imageURL := resolveComixURL(response.Pages.BaseURL, image.URL)
 		if imageURL == "" {
-			return fmt.Errorf("getting Comix image URLs for chapter %s: page %d URL is empty", chapter.ID, i+1)
+			return nil, fmt.Errorf("getting Comix image URLs for chapter %s: page %d URL is empty", chapter.ID, i+1)
 		}
 		imageInfo := domain.ImageInfo{
 			ImageURL: imageURL,
@@ -236,8 +248,7 @@ func (c *comix) GetImageURLs(ctx context.Context, chapter *domain.Chapter) error
 		imageInfos = append(imageInfos, imageInfo)
 	}
 
-	chapter.ImageInfo = imageInfos
-	return nil
+	return imageInfos, nil
 }
 
 func (c *comix) get(ctx context.Context, path string, params comixParams, destination any) error {

--- a/internal/source/comix_test.go
+++ b/internal/source/comix_test.go
@@ -119,7 +119,7 @@ func TestComixCodecRejectsInvalidEnvelope(t *testing.T) {
 	require.ErrorContains(t, err, "decoding Comix encrypted payload")
 }
 
-func TestComixGetMangaUsesCurrentEncryptedAPI(t *testing.T) {
+func TestComixMangaUsesCurrentEncryptedAPI(t *testing.T) {
 	t.Parallel()
 
 	codec, err := newComixCodec()
@@ -146,7 +146,7 @@ func TestComixGetMangaUsesCurrentEncryptedAPI(t *testing.T) {
 	defer server.Close()
 
 	source := newTestComix(t, server, "https://comix.to/title/pvry-one-piece", "")
-	manga, err := source.GetManga(t.Context())
+	manga, err := source.getManga(t.Context())
 	require.NoError(t, err)
 	require.Equal(t, "pvry", manga.ID)
 	require.Equal(t, "One Piece", manga.Title)
@@ -155,7 +155,7 @@ func TestComixGetMangaUsesCurrentEncryptedAPI(t *testing.T) {
 	require.NotNil(t, manga.Chapters)
 }
 
-func TestComixGetChaptersPaginatesAndFiltersGroup(t *testing.T) {
+func TestComixChaptersPaginatesAndFiltersGroup(t *testing.T) {
 	t.Parallel()
 
 	codec, err := newComixCodec()
@@ -204,13 +204,13 @@ func TestComixGetChaptersPaginatesAndFiltersGroup(t *testing.T) {
 
 	source := newTestComix(t, server, "https://comix.to/title/pvry-one-piece", "6594")
 	manga := domain.Manga{ID: "pvry", Chapters: make(map[domain.ChapterNumber]domain.Chapter)}
-	require.NoError(t, source.GetChapters(t.Context(), manga))
+	require.NoError(t, source.getChapters(t.Context(), manga))
 	require.Len(t, manga.Chapters, 2)
 	require.Equal(t, "101", manga.Chapters[domain.MustParseChapterNumber("11")].ID)
 	require.Equal(t, server.URL+"/chapter/2", manga.Chapters[domain.MustParseChapterNumber("10")].URL)
 }
 
-func TestComixGetImageURLsNormalizesCompactPages(t *testing.T) {
+func TestComixPagesNormalizesCompactPages(t *testing.T) {
 	t.Parallel()
 
 	codec, err := newComixCodec()
@@ -232,17 +232,18 @@ func TestComixGetImageURLsNormalizesCompactPages(t *testing.T) {
 
 	source := newTestComix(t, server, "https://comix.to/title/pvry-one-piece", "")
 	chapter := domain.Chapter{ID: "101"}
-	require.NoError(t, source.GetImageURLs(t.Context(), &chapter))
-	require.Len(t, chapter.ImageInfo, 2)
-	require.Equal(t, "https://images.example/one.webp", chapter.ImageInfo[0].ImageURL)
-	require.Equal(t, map[string]string{"Referer": server.URL + "/"}, chapter.ImageInfo[0].RequestHeaders)
-	require.Nil(t, chapter.ImageInfo[0].Processor)
-	require.Equal(t, "https://cdn.example/two.webp", chapter.ImageInfo[1].ImageURL)
-	require.Equal(t, map[string]string{"Referer": server.URL + "/"}, chapter.ImageInfo[1].RequestHeaders)
-	require.Nil(t, chapter.ImageInfo[1].Processor)
+	pages, err := source.Pages(t.Context(), chapter)
+	require.NoError(t, err)
+	require.Len(t, pages, 2)
+	require.Equal(t, "https://images.example/one.webp", pages[0].ImageURL)
+	require.Equal(t, map[string]string{"Referer": server.URL + "/"}, pages[0].RequestHeaders)
+	require.Nil(t, pages[0].Processor)
+	require.Equal(t, "https://cdn.example/two.webp", pages[1].ImageURL)
+	require.Equal(t, map[string]string{"Referer": server.URL + "/"}, pages[1].RequestHeaders)
+	require.Nil(t, pages[1].Processor)
 }
 
-func TestComixGetImageURLsMarksScrambledPage(t *testing.T) {
+func TestComixPagesMarksScrambledPage(t *testing.T) {
 	t.Parallel()
 
 	codec, err := newComixCodec()
@@ -261,10 +262,11 @@ func TestComixGetImageURLsMarksScrambledPage(t *testing.T) {
 
 	source := newTestComix(t, server, "https://comix.to/title/pvry-one-piece", "")
 	chapter := domain.Chapter{ID: "101"}
-	require.NoError(t, source.GetImageURLs(t.Context(), &chapter))
-	require.Len(t, chapter.ImageInfo, 2)
-	require.Nil(t, chapter.ImageInfo[0].Processor)
-	require.IsType(t, comixImageProcessor{}, chapter.ImageInfo[1].Processor)
+	pages, err := source.Pages(t.Context(), chapter)
+	require.NoError(t, err)
+	require.Len(t, pages, 2)
+	require.Nil(t, pages[0].Processor)
+	require.IsType(t, comixImageProcessor{}, pages[1].Processor)
 }
 
 func TestComixExtractIDRequiresCanonicalTitleURL(t *testing.T) {

--- a/internal/source/cubari.go
+++ b/internal/source/cubari.go
@@ -67,7 +67,7 @@ func (c *cubari) ValidateInput() error {
 	return nil
 }
 
-func (c *cubari) GetManga(ctx context.Context) (domain.Manga, error) {
+func (c *cubari) Discover(ctx context.Context) (domain.Manga, error) {
 	var cubariResp cubariResponse
 
 	if err := c.fetchJSON(ctx, c.MangaURL, &cubariResp); err != nil {
@@ -195,12 +195,12 @@ func (c *cubari) fetchJSON(ctx context.Context, rawURL string, target any) error
 	return nil
 }
 
-func (c *cubari) GetChapters(_ context.Context, _ domain.Manga) error {
-	return nil
-}
+func (c *cubari) Pages(_ context.Context, chapter domain.Chapter) ([]domain.ImageInfo, error) {
+	if len(chapter.ImageInfo) == 0 {
+		return nil, fmt.Errorf("getting image URLs for chapter %s", chapter.Number)
+	}
 
-func (c *cubari) GetImageURLs(_ context.Context, _ *domain.Chapter) error {
-	return nil
+	return chapter.ImageInfo, nil
 }
 
 func (c *cubari) getChapterName(chapterString string) string {

--- a/internal/source/cubari_test.go
+++ b/internal/source/cubari_test.go
@@ -23,7 +23,7 @@ func newTestCubari(mangaURL, baseURL string) *cubari {
 	}
 }
 
-func TestCubariGetMangaProxyChapter(t *testing.T) {
+func TestCubariDiscoverProxyChapter(t *testing.T) {
 	t.Parallel()
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -46,7 +46,7 @@ func TestCubariGetMangaProxyChapter(t *testing.T) {
 
 	src := newTestCubari(server.URL+"/gist", server.URL)
 
-	manga, err := src.GetManga(t.Context())
+	manga, err := src.Discover(t.Context())
 	require.NoError(t, err)
 
 	chapter, ok := manga.Chapters[domain.ChapterNumber{Whole: 236}]

--- a/internal/source/flamecomics.go
+++ b/internal/source/flamecomics.go
@@ -122,7 +122,7 @@ func (f *flamecomics) ValidateInput() error {
 	return nil
 }
 
-func (f *flamecomics) GetManga(ctx context.Context) (domain.Manga, error) {
+func (f *flamecomics) Discover(ctx context.Context) (domain.Manga, error) {
 	var responseData flamecomicsResponse
 	var errors []error
 
@@ -194,11 +194,7 @@ func (f *flamecomics) GetManga(ctx context.Context) (domain.Manga, error) {
 	return manga, nil
 }
 
-func (f *flamecomics) GetChapters(_ context.Context, _ domain.Manga) error {
-	return nil
-}
-
-func (f *flamecomics) GetImageURLs(ctx context.Context, chapter *domain.Chapter) error {
+func (f *flamecomics) Pages(ctx context.Context, chapter domain.Chapter) ([]domain.ImageInfo, error) {
 	var chapterResponse flamecomicsChapterResponse
 	var errors []error
 	c := f.Collector.Clone()
@@ -226,11 +222,11 @@ func (f *flamecomics) GetImageURLs(ctx context.Context, chapter *domain.Chapter)
 
 	err := c.Visit(chapter.URL)
 	if err != nil {
-		return fmt.Errorf("visiting URL %s: %w", chapter.URL, err)
+		return nil, fmt.Errorf("visiting URL %s: %w", chapter.URL, err)
 	}
 
 	if len(errors) > 0 {
-		return fmt.Errorf("processing %d URLs: %w", len(errors), errors[0])
+		return nil, fmt.Errorf("processing %d URLs: %w", len(errors), errors[0])
 	}
 
 	responseChapter := chapterResponse.Props.PageProps.Chapter
@@ -260,9 +256,8 @@ func (f *flamecomics) GetImageURLs(ctx context.Context, chapter *domain.Chapter)
 	}
 
 	if len(imageURLs) == 0 {
-		return fmt.Errorf("getting image URLs for chapter %s", chapter.Number)
+		return nil, fmt.Errorf("getting image URLs for chapter %s", chapter.Number)
 	}
 
-	chapter.ImageInfo = imageURLs
-	return nil
+	return imageURLs, nil
 }

--- a/internal/source/flamecomics_test.go
+++ b/internal/source/flamecomics_test.go
@@ -26,7 +26,7 @@ func TestFlameComicsFixtureFlow(t *testing.T) {
 	source.BaseURL = server.URL
 	source.CDNBaseURL = "https://cdn.example"
 
-	manga, err := source.GetManga(t.Context())
+	manga, err := source.Discover(t.Context())
 	if err != nil {
 		t.Fatalf("get manga: %v", err)
 	}
@@ -34,10 +34,11 @@ func TestFlameComicsFixtureFlow(t *testing.T) {
 		t.Fatalf("manga title = %q", manga.Title)
 	}
 	for _, chapter := range manga.Chapters {
-		if err := source.GetImageURLs(t.Context(), &chapter); err != nil {
+		pages, err := source.Pages(t.Context(), chapter)
+		if err != nil {
 			t.Fatalf("get image URLs: %v", err)
 		}
-		if got := chapter.ImageInfo[0].ImageURL; got != "https://cdn.example/uploads/images/series/7/chapter-token/001.webp" {
+		if got := pages[0].ImageURL; got != "https://cdn.example/uploads/images/series/7/chapter-token/001.webp" {
 			t.Fatalf("first image URL = %q", got)
 		}
 	}

--- a/internal/source/mangadex.go
+++ b/internal/source/mangadex.go
@@ -110,7 +110,19 @@ func (m *mangadex) ValidateInput() error {
 	return nil
 }
 
-func (m *mangadex) GetManga(ctx context.Context) (domain.Manga, error) {
+func (m *mangadex) Discover(ctx context.Context) (domain.Manga, error) {
+	manga, err := m.getManga(ctx)
+	if err != nil {
+		return domain.Manga{}, err
+	}
+	if err := m.getChapters(ctx, manga); err != nil {
+		return domain.Manga{}, err
+	}
+
+	return manga, nil
+}
+
+func (m *mangadex) getManga(ctx context.Context) (domain.Manga, error) {
 	var mangaResp mangadexManga
 	var isManhwa bool
 
@@ -167,7 +179,7 @@ func (m *mangadex) GetManga(ctx context.Context) (domain.Manga, error) {
 	}, nil
 }
 
-func (m *mangadex) GetChapters(ctx context.Context, manga domain.Manga) error {
+func (m *mangadex) getChapters(ctx context.Context, manga domain.Manga) error {
 	var retryErr error
 	var chapterResp mangadexChapters
 	var chapterCount int
@@ -257,18 +269,18 @@ func (m *mangadex) GetChapters(ctx context.Context, manga domain.Manga) error {
 	return nil
 }
 
-func (m *mangadex) GetImageURLs(ctx context.Context, chapter *domain.Chapter) error {
+func (m *mangadex) Pages(ctx context.Context, chapter domain.Chapter) ([]domain.ImageInfo, error) {
 	var chapterResp mangadexChapter
 	var imageInfos []domain.ImageInfo
 
 	path, err := url.JoinPath(m.BaseURL, "at-home/server", chapter.ID)
 	if err != nil {
-		return fmt.Errorf("building URL: %w", err)
+		return nil, fmt.Errorf("building URL: %w", err)
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, path, nil)
 	if err != nil {
-		return fmt.Errorf("creating request: %w", err)
+		return nil, fmt.Errorf("creating request: %w", err)
 	}
 
 	req.Header.Set("User-Agent", "mangarr")
@@ -292,24 +304,23 @@ func (m *mangadex) GetImageURLs(ctx context.Context, chapter *domain.Chapter) er
 		sharedhttp.RetryOptions(ctx)...,
 	)
 	if retryErr != nil {
-		return fmt.Errorf("executing request %s: %w", req.URL, retryErr)
+		return nil, fmt.Errorf("executing request %s: %w", req.URL, retryErr)
 	}
 
 	for _, imageURL := range chapterResp.Chapter.Data {
 		imagePath, err := url.JoinPath(chapterResp.BaseURL, "data", chapterResp.Chapter.Hash, imageURL)
 		if err != nil {
-			return fmt.Errorf("building URL: %w", err)
+			return nil, fmt.Errorf("building URL: %w", err)
 		}
 
 		imageInfos = append(imageInfos, domain.ImageInfo{ImageURL: imagePath})
 	}
 
 	if len(imageInfos) == 0 {
-		return fmt.Errorf("getting image URLs for chapter ID %s", chapter.ID)
+		return nil, fmt.Errorf("getting image URLs for chapter ID %s", chapter.ID)
 	}
 
-	chapter.ImageInfo = imageInfos
-	return nil
+	return imageInfos, nil
 }
 
 func (m *mangadex) getMangaTitle(titles map[string]string) string {

--- a/internal/source/mangadex_test.go
+++ b/internal/source/mangadex_test.go
@@ -38,15 +38,12 @@ func TestMangaDexPaginatesBeforeRejectingFilteredResults(t *testing.T) {
 	source.BaseURL = server.URL
 	source.Client = server.Client()
 
-	manga, err := source.GetManga(t.Context())
+	manga, err := source.Discover(t.Context())
 	if err != nil {
 		t.Fatalf("get manga: %v", err)
 	}
 	if manga.Title != "Fixture English" {
 		t.Fatalf("manga title = %q", manga.Title)
-	}
-	if err := source.GetChapters(t.Context(), manga); err != nil {
-		t.Fatalf("get chapters: %v", err)
 	}
 	if len(manga.Chapters) != 1 {
 		t.Fatalf("chapter count = %d, want 1", len(manga.Chapters))
@@ -56,11 +53,12 @@ func TestMangaDexPaginatesBeforeRejectingFilteredResults(t *testing.T) {
 		if chapter.ID != "chapter-selected" {
 			t.Fatalf("chapter ID = %q", chapter.ID)
 		}
-		if err := source.GetImageURLs(t.Context(), &chapter); err != nil {
+		pages, err := source.Pages(t.Context(), chapter)
+		if err != nil {
 			t.Fatalf("get image URLs: %v", err)
 		}
-		if len(chapter.ImageInfo) != 2 {
-			t.Fatalf("image count = %d, want 2", len(chapter.ImageInfo))
+		if len(pages) != 2 {
+			t.Fatalf("image count = %d, want 2", len(pages))
 		}
 	}
 }

--- a/internal/source/mangaplus.go
+++ b/internal/source/mangaplus.go
@@ -68,7 +68,7 @@ func (m *mangaplus) ValidateInput() error {
 	return nil
 }
 
-func (m *mangaplus) GetManga(ctx context.Context) (domain.Manga, error) {
+func (m *mangaplus) Discover(ctx context.Context) (domain.Manga, error) {
 	if err := m.ensureRegistered(ctx); err != nil {
 		return domain.Manga{}, fmt.Errorf("registering Manga Plus device: %w", err)
 	}
@@ -118,13 +118,9 @@ func (m *mangaplus) GetManga(ctx context.Context) (domain.Manga, error) {
 	}, nil
 }
 
-func (m *mangaplus) GetChapters(_ context.Context, _ domain.Manga) error {
-	return nil
-}
-
-func (m *mangaplus) GetImageURLs(ctx context.Context, chapter *domain.Chapter) error {
+func (m *mangaplus) Pages(ctx context.Context, chapter domain.Chapter) ([]domain.ImageInfo, error) {
 	if err := m.ensureRegistered(ctx); err != nil {
-		return fmt.Errorf("registering Manga Plus device: %w", err)
+		return nil, fmt.Errorf("registering Manga Plus device: %w", err)
 	}
 
 	params := url.Values{
@@ -137,19 +133,19 @@ func (m *mangaplus) GetImageURLs(ctx context.Context, chapter *domain.Chapter) e
 
 	path, err := url.JoinPath(m.baseURL, "manga_viewer")
 	if err != nil {
-		return fmt.Errorf("building URL: %w", err)
+		return nil, fmt.Errorf("building URL: %w", err)
 	}
 
 	u, err := url.Parse(path)
 	if err != nil {
-		return fmt.Errorf("parsing URL %s: %w", path, err)
+		return nil, fmt.Errorf("parsing URL %s: %w", path, err)
 	}
 
 	u.RawQuery = params.Encode()
 
 	protoResp, err := m.getProtoResponse(ctx, http.MethodGet, u.String())
 	if err != nil {
-		return fmt.Errorf("getting protobuf response: %w", err)
+		return nil, fmt.Errorf("getting protobuf response: %w", err)
 	}
 
 	var imageInfos []domain.ImageInfo
@@ -164,11 +160,10 @@ func (m *mangaplus) GetImageURLs(ctx context.Context, chapter *domain.Chapter) e
 	}
 
 	if len(imageInfos) == 0 {
-		return fmt.Errorf("getting image URLs for chapter ID %s", chapter.ID)
+		return nil, fmt.Errorf("getting image URLs for chapter ID %s", chapter.ID)
 	}
 
-	chapter.ImageInfo = imageInfos
-	return nil
+	return imageInfos, nil
 }
 
 func (m *mangaplus) ensureRegistered(ctx context.Context) error {

--- a/internal/source/mangaplus_test.go
+++ b/internal/source/mangaplus_test.go
@@ -13,7 +13,7 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-func TestMangaPlusGetMangaRegistersAndUsesSecret(t *testing.T) {
+func TestMangaPlusDiscoverRegistersAndUsesSecret(t *testing.T) {
 	t.Parallel()
 
 	var registered atomic.Bool
@@ -54,13 +54,13 @@ func TestMangaPlusGetMangaRegistersAndUsesSecret(t *testing.T) {
 		baseURL: server.URL + "/api",
 	}
 
-	manga, err := src.GetManga(t.Context())
+	manga, err := src.Discover(t.Context())
 	require.NoError(t, err)
 	require.Equal(t, "Registered Title", manga.Title)
 	require.Equal(t, "registered-secret", src.secret)
 }
 
-func TestMangaPlusGetMangaParsesChapterListV2(t *testing.T) {
+func TestMangaPlusDiscoverParsesChapterListV2(t *testing.T) {
 	t.Parallel()
 
 	titleDetail := &protobuf.TitleDetailView{
@@ -83,7 +83,7 @@ func TestMangaPlusGetMangaParsesChapterListV2(t *testing.T) {
 
 	src := newTestMangaPlus("100352", server)
 
-	manga, err := src.GetManga(t.Context())
+	manga, err := src.Discover(t.Context())
 	require.NoError(t, err)
 	require.Equal(t, "Hero Organization", manga.Title)
 	require.Len(t, manga.Chapters, 2)
@@ -99,7 +99,7 @@ func TestMangaPlusGetMangaParsesChapterListV2(t *testing.T) {
 	require.Equal(t, "Chapter 2: HEROES", chapter2.Title)
 }
 
-func TestMangaPlusGetMangaKeepsLegacyChapterGroups(t *testing.T) {
+func TestMangaPlusDiscoverKeepsLegacyChapterGroups(t *testing.T) {
 	t.Parallel()
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -125,14 +125,14 @@ func TestMangaPlusGetMangaKeepsLegacyChapterGroups(t *testing.T) {
 
 	src := newTestMangaPlus("100352", server)
 
-	manga, err := src.GetManga(t.Context())
+	manga, err := src.Discover(t.Context())
 	require.NoError(t, err)
 	require.Len(t, manga.Chapters, 2)
 	require.Equal(t, "1001", manga.Chapters[domain.MustParseChapterNumber("1")].ID)
 	require.Equal(t, "1002", manga.Chapters[domain.MustParseChapterNumber("10")].ID)
 }
 
-func TestMangaPlusGetImageURLsParsesViewerPages(t *testing.T) {
+func TestMangaPlusPagesParsesViewerPages(t *testing.T) {
 	t.Parallel()
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -157,12 +157,12 @@ func TestMangaPlusGetImageURLsParsesViewerPages(t *testing.T) {
 	src := newTestMangaPlus("100352", server)
 	chapter := domain.Chapter{ID: "1022325"}
 
-	err := src.GetImageURLs(t.Context(), &chapter)
+	pages, err := src.Pages(t.Context(), chapter)
 	require.NoError(t, err)
 	require.Equal(t, []domain.ImageInfo{
 		{ImageURL: "https://cdn.example/page-001.webp", EncryptionKey: "abc"},
 		{ImageURL: "https://cdn.example/page-002.webp"},
-	}, chapter.ImageInfo)
+	}, pages)
 }
 
 func newTestMangaPlus(mangaID string, server *httptest.Server) *mangaplus {

--- a/internal/source/source.go
+++ b/internal/source/source.go
@@ -6,27 +6,29 @@ import (
 	"mangarr/internal/domain"
 )
 
+type constructor func(domain.MonitoredManga) domain.Source
+
+var registry = map[string]constructor{
+	"asurascans": func(m domain.MonitoredManga) domain.Source { return NewAsurascans(m.Manga) },
+	"atsumaru":   func(m domain.MonitoredManga) domain.Source { return NewAtsumaru(m.Manga, m.Group) },
+	"comix":      func(m domain.MonitoredManga) domain.Source { return NewComix(m.Manga, m.Group) },
+	"cubari":     func(m domain.MonitoredManga) domain.Source { return NewCubari(m.Manga, m.Group) },
+	"flamecomics": func(m domain.MonitoredManga) domain.Source {
+		return NewFlamecomics(m.Manga)
+	},
+	"mangadex": func(m domain.MonitoredManga) domain.Source {
+		return NewMangadex(m.Manga, m.Group, m.Language)
+	},
+	"mangaplus":   func(m domain.MonitoredManga) domain.Source { return NewMangaPlus(m.Manga) },
+	"tcbscans":    func(m domain.MonitoredManga) domain.Source { return NewTCBScans(m.Manga) },
+	"weebcentral": func(m domain.MonitoredManga) domain.Source { return NewWeebCentral(m.Manga) },
+}
+
 func Select(monitoredManga domain.MonitoredManga) (domain.Source, error) {
-	switch monitoredManga.Source {
-	case "tcbscans":
-		return NewTCBScans(monitoredManga.Manga), nil
-	case "mangadex":
-		return NewMangadex(monitoredManga.Manga, monitoredManga.Group, monitoredManga.Language), nil
-	case "mangaplus":
-		return NewMangaPlus(monitoredManga.Manga), nil
-	case "flamecomics":
-		return NewFlamecomics(monitoredManga.Manga), nil
-	case "asurascans":
-		return NewAsurascans(monitoredManga.Manga), nil
-	case "cubari":
-		return NewCubari(monitoredManga.Manga, monitoredManga.Group), nil
-	case "weebcentral":
-		return NewWeebCentral(monitoredManga.Manga), nil
-	case "comix":
-		return NewComix(monitoredManga.Manga, monitoredManga.Group), nil
-	case "atsumaru":
-		return NewAtsumaru(monitoredManga.Manga, monitoredManga.Group), nil
+	newSource, ok := registry[monitoredManga.Source]
+	if !ok {
+		return nil, fmt.Errorf("unknown monitored manga source %s", monitoredManga.Source)
 	}
 
-	return nil, fmt.Errorf("unknown monitored manga source %s", monitoredManga.Source)
+	return newSource(monitoredManga), nil
 }

--- a/internal/source/source_test.go
+++ b/internal/source/source_test.go
@@ -1,0 +1,45 @@
+package source
+
+import (
+	"testing"
+
+	"mangarr/internal/domain"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSelectSupportsEveryRegisteredSource(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		identifier string
+		name       string
+	}{
+		{identifier: "asurascans", name: "Asura Scans"},
+		{identifier: "atsumaru", name: "Atsumaru"},
+		{identifier: "comix", name: "Comix"},
+		{identifier: "cubari", name: "Cubari"},
+		{identifier: "flamecomics", name: "Flame Comics"},
+		{identifier: "mangadex", name: "MangaDex"},
+		{identifier: "mangaplus", name: "MANGA Plus"},
+		{identifier: "tcbscans", name: "TCB Scans"},
+		{identifier: "weebcentral", name: "Weeb Central"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.identifier, func(t *testing.T) {
+			t.Parallel()
+
+			src, err := Select(domain.MonitoredManga{Source: tt.identifier})
+			require.NoError(t, err)
+			require.Equal(t, tt.name, src.String())
+		})
+	}
+}
+
+func TestSelectRejectsUnknownSource(t *testing.T) {
+	t.Parallel()
+
+	_, err := Select(domain.MonitoredManga{Source: "unknown"})
+	require.EqualError(t, err, "unknown monitored manga source unknown")
+}

--- a/internal/source/tcbscans.go
+++ b/internal/source/tcbscans.go
@@ -54,8 +54,20 @@ func (t *tcbscans) ValidateInput() error {
 	return nil
 }
 
-// GetManga gets the selected manga from TCB Scans
-func (t *tcbscans) GetManga(ctx context.Context) (domain.Manga, error) {
+// Discover gets the selected manga and its chapters from TCB Scans.
+func (t *tcbscans) Discover(ctx context.Context) (domain.Manga, error) {
+	manga, err := t.getManga(ctx)
+	if err != nil {
+		return domain.Manga{}, err
+	}
+	if err := t.getChapters(ctx, manga); err != nil {
+		return domain.Manga{}, err
+	}
+
+	return manga, nil
+}
+
+func (t *tcbscans) getManga(ctx context.Context) (domain.Manga, error) {
 	mangas := make(map[string]domain.Manga)
 	var errors []error
 	c := t.Collector.Clone()
@@ -98,8 +110,7 @@ func (t *tcbscans) GetManga(ctx context.Context) (domain.Manga, error) {
 	return selectedManga, nil
 }
 
-// GetChapters gets all chapters for a manga
-func (t *tcbscans) GetChapters(ctx context.Context, manga domain.Manga) error {
+func (t *tcbscans) getChapters(ctx context.Context, manga domain.Manga) error {
 	var errors []error
 	c := t.Collector.Clone()
 	c.Context = ctx
@@ -148,8 +159,8 @@ func (t *tcbscans) GetChapters(ctx context.Context, manga domain.Manga) error {
 	return nil
 }
 
-// GetImageURLs gets all image urls for a chapter
-func (t *tcbscans) GetImageURLs(ctx context.Context, chapter *domain.Chapter) error {
+// Pages gets all image URLs for a chapter.
+func (t *tcbscans) Pages(ctx context.Context, chapter domain.Chapter) ([]domain.ImageInfo, error) {
 	var imageInfos []domain.ImageInfo
 	var errors []error
 	c := t.Collector.Clone()
@@ -165,24 +176,23 @@ func (t *tcbscans) GetImageURLs(ctx context.Context, chapter *domain.Chapter) er
 
 	path, err := url.JoinPath(t.BaseURL, chapter.URL)
 	if err != nil {
-		return fmt.Errorf("building URL: %w", err)
+		return nil, fmt.Errorf("building URL: %w", err)
 	}
 
 	err = c.Visit(path)
 	if err != nil {
-		return fmt.Errorf("visiting URL %s: %w", path, err)
+		return nil, fmt.Errorf("visiting URL %s: %w", path, err)
 	}
 
 	if len(errors) > 0 {
-		return fmt.Errorf("processing %d URLs: %w", len(errors), errors[0])
+		return nil, fmt.Errorf("processing %d URLs: %w", len(errors), errors[0])
 	}
 
 	if len(imageInfos) == 0 {
-		return fmt.Errorf("getting image URLs for chapter %s", chapter.Number)
+		return nil, fmt.Errorf("getting image URLs for chapter %s", chapter.Number)
 	}
 
-	chapter.ImageInfo = imageInfos
-	return nil
+	return imageInfos, nil
 }
 
 // getChapterNumber gets the chapter number from the scraped chapter name

--- a/internal/source/tcbscans_test.go
+++ b/internal/source/tcbscans_test.go
@@ -29,23 +29,21 @@ func TestTCBScansFixtureFlow(t *testing.T) {
 	source := NewTCBScans("One Piece").(*tcbscans)
 	source.BaseURL = server.URL
 
-	manga, err := source.GetManga(t.Context())
+	manga, err := source.Discover(t.Context())
 	if err != nil {
-		t.Fatalf("get manga: %v", err)
-	}
-	if err := source.GetChapters(t.Context(), manga); err != nil {
-		t.Fatalf("get chapters: %v", err)
+		t.Fatalf("discover manga: %v", err)
 	}
 	if len(manga.Chapters) != 1 {
 		t.Fatalf("chapter count = %d, want 1", len(manga.Chapters))
 	}
 
 	for _, chapter := range manga.Chapters {
-		if err := source.GetImageURLs(t.Context(), &chapter); err != nil {
+		pages, err := source.Pages(t.Context(), chapter)
+		if err != nil {
 			t.Fatalf("get image URLs: %v", err)
 		}
-		if len(chapter.ImageInfo) != 2 {
-			t.Fatalf("image count = %d, want 2", len(chapter.ImageInfo))
+		if len(pages) != 2 {
+			t.Fatalf("image count = %d, want 2", len(pages))
 		}
 	}
 }
@@ -61,7 +59,7 @@ func TestTCBScansHonorsContextCancellation(t *testing.T) {
 	ctx, cancel := context.WithTimeout(t.Context(), 20*time.Millisecond)
 	defer cancel()
 
-	if _, err := source.GetManga(ctx); err == nil {
+	if _, err := source.Discover(ctx); err == nil {
 		t.Fatal("expected canceled scrape to fail")
 	}
 }

--- a/internal/source/weebcentral.go
+++ b/internal/source/weebcentral.go
@@ -73,8 +73,20 @@ func (w *weebcentral) ValidateInput() error {
 	return nil
 }
 
-// GetManga gets the selected manga from Weeb Central
-func (w *weebcentral) GetManga(ctx context.Context) (domain.Manga, error) {
+// Discover gets the selected manga and its chapters from Weeb Central.
+func (w *weebcentral) Discover(ctx context.Context) (domain.Manga, error) {
+	manga, err := w.getManga(ctx)
+	if err != nil {
+		return domain.Manga{}, err
+	}
+	if err := w.getChapters(ctx, manga); err != nil {
+		return domain.Manga{}, err
+	}
+
+	return manga, nil
+}
+
+func (w *weebcentral) getManga(ctx context.Context) (domain.Manga, error) {
 	var manga domain.Manga
 	var errors []error
 	c := w.Collector.Clone()
@@ -103,8 +115,7 @@ func (w *weebcentral) GetManga(ctx context.Context) (domain.Manga, error) {
 	return manga, nil
 }
 
-// GetChapters gets all chapters for a manga
-func (w *weebcentral) GetChapters(ctx context.Context, manga domain.Manga) error {
+func (w *weebcentral) getChapters(ctx context.Context, manga domain.Manga) error {
 	var errors []error
 	c := w.Collector.Clone()
 	c.Context = ctx
@@ -154,25 +165,25 @@ func (w *weebcentral) GetChapters(ctx context.Context, manga domain.Manga) error
 	return nil
 }
 
-// GetImageURLs gets all image urls for a chapter
-func (w *weebcentral) GetImageURLs(ctx context.Context, chapter *domain.Chapter) error {
+// Pages gets all image URLs for a chapter.
+func (w *weebcentral) Pages(ctx context.Context, chapter domain.Chapter) ([]domain.ImageInfo, error) {
 	imageURL, err := w.chapterImagesURL(chapter.URL)
 	if err != nil {
-		return fmt.Errorf("building chapter images URL from %s: %w", chapter.URL, err)
+		return nil, fmt.Errorf("building chapter images URL from %s: %w", chapter.URL, err)
 	}
 
 	body, err := w.fetch(ctx, imageURL)
 	if err != nil {
-		return fmt.Errorf("fetching chapter images %s: %w", imageURL, err)
+		return nil, fmt.Errorf("fetching chapter images %s: %w", imageURL, err)
 	}
 
 	imageURLs, err := w.extractImageURLs(body)
 	if err != nil {
-		return fmt.Errorf("extracting chapter image URLs from %s: %w", imageURL, err)
+		return nil, fmt.Errorf("extracting chapter image URLs from %s: %w", imageURL, err)
 	}
 
 	if len(imageURLs) == 0 {
-		return fmt.Errorf("getting image URLs for chapter %s", chapter.Number)
+		return nil, fmt.Errorf("getting image URLs for chapter %s", chapter.Number)
 	}
 
 	imageInfos := make([]domain.ImageInfo, 0, len(imageURLs))
@@ -180,8 +191,7 @@ func (w *weebcentral) GetImageURLs(ctx context.Context, chapter *domain.Chapter)
 		imageInfos = append(imageInfos, domain.ImageInfo{ImageURL: imageURL})
 	}
 
-	chapter.ImageInfo = imageInfos
-	return nil
+	return imageInfos, nil
 }
 
 func (w *weebcentral) chapterImagesURL(chapterURL string) (string, error) {

--- a/internal/source/weebcentral_test.go
+++ b/internal/source/weebcentral_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestWeebCentralGetImageURLsExtractsChapterAssets(t *testing.T) {
+func TestWeebCentralPagesExtractsChapterAssets(t *testing.T) {
 	t.Parallel()
 
 	const chapterPath = "/chapters/01TESTCHAPTER"
@@ -46,11 +46,11 @@ func TestWeebCentralGetImageURLsExtractsChapterAssets(t *testing.T) {
 		Number: domain.MustParseChapterNumber("340.2"),
 	}
 
-	err := src.GetImageURLs(t.Context(), &chapter)
+	pages, err := src.Pages(t.Context(), chapter)
 	require.NoError(t, err)
-	require.Len(t, chapter.ImageInfo, 2)
-	require.Equal(t, "https://cdn.weebcentral.test/manga/chapter-001.png", chapter.ImageInfo[0].ImageURL)
-	require.Equal(t, server.URL+"/media/chapter-002.png", chapter.ImageInfo[1].ImageURL)
+	require.Len(t, pages, 2)
+	require.Equal(t, "https://cdn.weebcentral.test/manga/chapter-001.png", pages[0].ImageURL)
+	require.Equal(t, server.URL+"/media/chapter-002.png", pages[1].ImageURL)
 }
 
 func TestWeebCentralResolvesRelativeChapterURLs(t *testing.T) {
@@ -77,13 +77,14 @@ func TestWeebCentralResolvesRelativeChapterURLs(t *testing.T) {
 		Chapters: make(map[domain.ChapterNumber]domain.Chapter),
 	}
 
-	require.NoError(t, src.GetChapters(t.Context(), manga))
+	require.NoError(t, src.getChapters(t.Context(), manga))
 	chapter := manga.Chapters[chapterNumber]
-	require.NoError(t, src.GetImageURLs(t.Context(), &chapter))
-	require.Equal(t, server.URL+"/media/chapter-356.png", chapter.ImageInfo[0].ImageURL)
+	pages, err := src.Pages(t.Context(), chapter)
+	require.NoError(t, err)
+	require.Equal(t, server.URL+"/media/chapter-356.png", pages[0].ImageURL)
 }
 
-func TestWeebCentralGetImageURLsErrorsWhenFragmentHasNoImages(t *testing.T) {
+func TestWeebCentralPagesErrorsWhenFragmentHasNoImages(t *testing.T) {
 	t.Parallel()
 
 	const chapterPath = "/chapters/01EMPTYCHAPTER"
@@ -105,7 +106,7 @@ func TestWeebCentralGetImageURLsErrorsWhenFragmentHasNoImages(t *testing.T) {
 		Number: domain.MustParseChapterNumber("1"),
 	}
 
-	err := src.GetImageURLs(t.Context(), &chapter)
+	_, err := src.Pages(t.Context(), chapter)
 	require.EqualError(t, err, "getting image URLs for chapter 1")
 }
 


### PR DESCRIPTION
<!-- ship-stack:start -->
## PR stack

> [!NOTE]
> This PR is part of a stack. Merge it with the full stack when ready.

Depends on:
- #105

Followed by:
- #107
<!-- ship-stack:end -->

## Why

Source adapters exposed a mutation-based lifecycle with required no-op methods, and download duplicated the monitor source switch.

## What changed

- Replace the adapter lifecycle with `Discover` and `Pages` return values.
- Remove required no-op chapter and page methods.
- Route download and monitor through one tested source registry.
- Update adapter tests and design documentation for the truthful contract.

## Tests

- `go test ./...`
- `go test -race ./...`
- `go build ./...`
