### PR TITLE
refactor(download): centralize chapter acquisition

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -17,7 +17,7 @@ Verified against code on 2026-03-25.
 | Download now | `cmd/download.go` | source selection, chapter selection, archive write |
 | Continuous monitor | `cmd/monitor.go` | config load, ticker loop, dynamic reload, latest-chapter fetch |
 | Source integration | `internal/source/` | highest churn; mixed API, HTML scraping, browser automation |
-| Archive assembly | `internal/download/`, `internal/files/` | image fetch, retry, CBZ creation |
+| Chapter acquisition | `internal/acquire/`, `internal/download/`, `internal/files/` | naming, existing-file policy, page resolution, image fetch, CBZ creation |
 | Ops + packaging | `.github/workflows/release.yml`, `.goreleaser.yaml`, `ci.Dockerfile` | release binaries and multi-arch Docker images |
 
 ## Package Layering
@@ -25,7 +25,7 @@ Verified against code on 2026-03-25.
 | Layer | Packages | Responsibility |
 | --- | --- | --- |
 | CLI surface | `main.go`, `cmd/` | parse flags, bootstrap commands, orchestrate flows |
-| Application orchestration | `cmd/`, `internal/config/`, `internal/browser/` | compose sources, concurrency, config/runtime lifecycle |
+| Application orchestration | `cmd/`, `internal/acquire/`, `internal/config/`, `internal/browser/` | compose sources, acquire chapters, concurrency, config/runtime lifecycle |
 | Core domain helpers | `internal/domain/`, `internal/parse/`, `internal/templater/`, `internal/sanitize/`, `internal/semaphore/` | shared logic independent from any source |
 | Integration layer | `internal/source/`, `internal/sharedhttp/`, `internal/download/` | fetch remote data, retry transient failures, browser-backed scraping |
 | Output + observability | `internal/files/`, `internal/logger/`, `internal/perf/`, `internal/buildinfo/` | archive write, logging, profiling, build metadata |
@@ -40,10 +40,10 @@ Rule: source-specific scraping logic stays in `internal/source/`. Generic retry,
 2. Construct source adapter from `-s`.
 3. Fetch manga metadata and chapter list.
 4. Resolve requested chapter set.
-5. Skip existing archives.
-6. Fetch image URLs.
-7. Download images concurrently.
-8. Write `.cbz`.
+5. Pass each selected chapter to `internal/acquire/`.
+6. Apply naming and existing-file policy.
+7. Resolve and download pages concurrently.
+8. Publish the `.cbz` archive.
 
 ### `monitor`
 
@@ -52,8 +52,8 @@ Rule: source-specific scraping logic stays in `internal/source/`. Generic retry,
 3. Start config reload watcher.
 4. Tick on `checkInterval`.
 5. For each monitored manga, resolve source adapter.
-6. Fetch latest chapter and skip if archive already exists.
-7. Download and archive latest chapter.
+6. Pass the latest chapter to the shared acquisition module.
+7. Report its downloaded or skipped outcome.
 
 ## Cross-Cutting Concerns
 

--- a/cmd/download.go
+++ b/cmd/download.go
@@ -3,19 +3,16 @@ package cmd
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 	"slices"
 	"sync"
 	"time"
 
+	"mangarr/internal/acquire"
 	"mangarr/internal/domain"
-	"mangarr/internal/download"
 	"mangarr/internal/files"
 	"mangarr/internal/parse"
-	"mangarr/internal/sanitize"
 	"mangarr/internal/semaphore"
 	"mangarr/internal/source"
-	"mangarr/internal/templater"
 
 	"github.com/rs/zerolog"
 	"github.com/spf13/cobra"
@@ -84,11 +81,6 @@ func newDownloadCommand(options *downloadOptions) *cobra.Command {
 				return fmt.Errorf("finding matching chapters in range %s for %s", options.chapterNumbers, selectedManga.Title)
 			}
 
-			overwrittenTitle := sanitize.Filename(options.overwrite)
-			if len(overwrittenTitle) != 0 {
-				selectedManga.Title = overwrittenTitle
-			}
-
 			const (
 				chapterStatusDownloaded = "downloaded"
 				chapterStatusSkipped    = "skipped"
@@ -132,34 +124,28 @@ func newDownloadCommand(options *downloadOptions) *cobra.Command {
 						return
 					}
 
-					t := templater.New(selectedManga, selectedChapter)
-					templatedName := t.ExecTemplate(options.naming)
+					acquisition, err := acquire.Chapter(ctx, log, acquire.Request{
+						Source:            s,
+						Manga:             selectedManga,
+						Chapter:           selectedChapter,
+						DownloadDirectory: options.downloadDirectory,
+						NamingTemplate:    options.naming,
+						TitleOverride:     options.overwrite,
+					})
+					if err != nil {
+						log.Error().Err(err).Msgf("Failed to acquire chapter %s", selectedChapter.Number)
+						return
+					}
 
-					chapterFolder := sanitize.Filename(templatedName)
-					contentPath := filepath.Join(options.downloadDirectory, selectedManga.Title, chapterFolder+".cbz")
-
-					if _, err := os.Stat(contentPath); err == nil {
-						log.Info().Msgf("Chapter has already been downloaded, skipping %q", templatedName)
+					switch acquisition.Status {
+					case acquire.Skipped:
+						log.Info().Msgf("Chapter has already been downloaded, skipping %q", acquisition.Name)
 						result.status = chapterStatusSkipped
 						shouldDelay = false
-						return
+					case acquire.Downloaded:
+						log.Info().Msgf("Finished downloading %q", acquisition.Name)
+						result.status = chapterStatusDownloaded
 					}
-
-					pages, err := s.Pages(ctx, selectedChapter)
-					if err != nil {
-						log.Error().Err(err).Msgf("Failed to get image URLs for chapter %s", selectedChapter.Number)
-						return
-					}
-					selectedChapter.ImageInfo = pages
-
-					log.Info().Msgf("Downloading %q", templatedName)
-					if err := download.Chapter(ctx, log, contentPath, selectedChapter, selectedManga.IsManhwa, files.CreateCbzArchive); err != nil {
-						log.Error().Err(err).Msgf("Failed to download chapter %q", templatedName)
-						return
-					}
-
-					log.Info().Msgf("Finished downloading %q", templatedName)
-					result.status = chapterStatusDownloaded
 				})
 			}
 

--- a/cmd/monitor.go
+++ b/cmd/monitor.go
@@ -3,23 +3,19 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"os"
 	"os/signal"
-	"path/filepath"
 	"syscall"
 	"time"
 
+	"mangarr/internal/acquire"
 	"mangarr/internal/buildinfo"
 	"mangarr/internal/config"
 	"mangarr/internal/domain"
-	"mangarr/internal/download"
 	"mangarr/internal/files"
 	"mangarr/internal/logger"
 	"mangarr/internal/parse"
 	"mangarr/internal/perf"
-	"mangarr/internal/sanitize"
 	"mangarr/internal/source"
-	"mangarr/internal/templater"
 
 	"github.com/spf13/cobra"
 	"golang.org/x/sync/errgroup"
@@ -153,30 +149,22 @@ func monitorManga(ctx context.Context, cfg domain.Config, mangaTitle string, mon
 		return fmt.Errorf("finding chapter with number %s", latestChapterNr)
 	}
 
-	if overwrittenTitle := sanitize.Filename(monitoredManga.Overwrite); overwrittenTitle != "" {
-		selectedManga.Title = overwrittenTitle
+	result, err := acquire.Chapter(ctx, mLog, acquire.Request{
+		Source:            mangaSource,
+		Manga:             selectedManga,
+		Chapter:           selectedChapter,
+		DownloadDirectory: cfg.DownloadLocation,
+		NamingTemplate:    cfg.NamingTemplate,
+		TitleOverride:     monitoredManga.Overwrite,
+	})
+	if err != nil {
+		return err
 	}
-
-	t := templater.New(selectedManga, selectedChapter)
-	templatedName := t.ExecTemplate(cfg.NamingTemplate)
-	chapterFolder := sanitize.Filename(templatedName)
-	contentPath := filepath.Join(cfg.DownloadLocation, selectedManga.Title, chapterFolder+".cbz")
-	if _, err := os.Stat(contentPath); err == nil {
-		mLog.Debug().Msgf("chapter has already been downloaded, skipping %s", templatedName)
+	if result.Status == acquire.Skipped {
+		mLog.Debug().Msgf("chapter has already been downloaded, skipping %s", result.Name)
 		return nil
 	}
-
-	pages, err := mangaSource.Pages(ctx, selectedChapter)
-	if err != nil {
-		return fmt.Errorf("getting image URLs for chapter %s: %w", selectedChapter.Number, err)
-	}
-	selectedChapter.ImageInfo = pages
-
-	mLog.Info().Msgf("downloading %q", templatedName)
-	if err := download.Chapter(ctx, mLog, contentPath, selectedChapter, selectedManga.IsManhwa, files.CreateCbzArchive); err != nil {
-		return fmt.Errorf("downloading chapter %s: %w", templatedName, err)
-	}
-	mLog.Info().Msgf("finished downloading %s", templatedName)
+	mLog.Info().Msgf("finished downloading %s", result.Name)
 
 	return nil
 }

--- a/docs/design-docs/source-adapters.md
+++ b/docs/design-docs/source-adapters.md
@@ -39,7 +39,7 @@ All adapters implement the small `domain.Source` contract:
 - `weebcentral` fetches chapter images from the `/chapters/<id>/images` HTML fragment
 - `comix` implements frontend build `35595e3de3c99889c1aa70`; it generates request tokens, decodes encrypted API envelopes, sends image request headers, and reconstructs scrambled tile images
 - `atsumaru` fetches chapter metadata from `/api/manga/info`, filters chapters by scan ID, and resolves relative page paths from `/api/read/chapter`
-- source-specific image transforms use `domain.ImageProcessor`; the downloader owns transport and output while the source adapter owns the transform
+- source-specific image transforms use `domain.ImageProcessor`; the acquisition path owns transport and output while the source adapter owns the transform
 - retry policy comes from `internal/sharedhttp/`
 - HTTP and Colly-backed requests inherit caller cancellation
 - fixture-backed parser flows cover every supported source

--- a/docs/exec-plans/active/2026-08-07-codebase-reliability-stack.md
+++ b/docs/exec-plans/active/2026-08-07-codebase-reliability-stack.md
@@ -147,3 +147,16 @@ download and monitor.
 
 Notes/risks: Discovery still retrieves the full chapter list because both current
 command flows need it. The next bucket centralizes the shared per-chapter work.
+
+## Bucket 7 - Chapter acquisition module - ALIGNED
+
+Built: Added one chapter-acquisition operation that owns title overrides, naming,
+archive paths, existing-file checks, page resolution, image download, atomic CBZ
+publication, and downloaded or skipped outcomes. Download and monitor both use it.
+
+Serves goal/decision because: The two user flows now share one reliability policy
+for every operation after chapter selection, with an end-to-end regression test
+across page resolution, image transport, archive creation, and skip behavior.
+
+Notes/risks: Chapter selection and caller-specific summary logging remain in the
+commands because those behaviors differ between one-shot and monitor modes.

--- a/internal/acquire/acquire.go
+++ b/internal/acquire/acquire.go
@@ -1,0 +1,83 @@
+// Package acquire resolves and stores one manga chapter.
+package acquire
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"mangarr/internal/domain"
+	"mangarr/internal/download"
+	"mangarr/internal/files"
+	"mangarr/internal/sanitize"
+	"mangarr/internal/templater"
+
+	"github.com/rs/zerolog"
+)
+
+type Status uint8
+
+const (
+	Downloaded Status = iota
+	Skipped
+)
+
+type PageSource interface {
+	Pages(context.Context, domain.Chapter) ([]domain.ImageInfo, error)
+}
+
+type Request struct {
+	Source            PageSource
+	Manga             domain.Manga
+	Chapter           domain.Chapter
+	DownloadDirectory string
+	NamingTemplate    string
+	TitleOverride     string
+}
+
+type Result struct {
+	Status Status
+	Name   string
+	Path   string
+}
+
+func Chapter(ctx context.Context, log zerolog.Logger, request Request) (Result, error) {
+	manga := request.Manga
+	if title := sanitize.Filename(request.TitleOverride); title != "" {
+		manga.Title = title
+	}
+
+	name := templater.New(manga, request.Chapter).ExecTemplate(request.NamingTemplate)
+	archiveName := sanitize.Filename(name) + ".cbz"
+	archivePath := filepath.Join(request.DownloadDirectory, manga.Title, archiveName)
+	result := Result{Name: name, Path: archivePath}
+
+	if _, err := os.Stat(archivePath); err == nil {
+		result.Status = Skipped
+		return result, nil
+	} else if !os.IsNotExist(err) {
+		return result, fmt.Errorf("checking archive %s: %w", archivePath, err)
+	}
+
+	pages, err := request.Source.Pages(ctx, request.Chapter)
+	if err != nil {
+		return result, fmt.Errorf("getting pages for chapter %s: %w", request.Chapter.Number, err)
+	}
+	request.Chapter.ImageInfo = pages
+
+	log.Info().Msgf("Downloading %q", name)
+	if err := download.Chapter(
+		ctx,
+		log,
+		archivePath,
+		request.Chapter,
+		manga.IsManhwa,
+		files.CreateCbzArchive,
+	); err != nil {
+		return result, fmt.Errorf("downloading chapter %q: %w", name, err)
+	}
+
+	result.Status = Downloaded
+	return result, nil
+}

--- a/internal/acquire/acquire_test.go
+++ b/internal/acquire/acquire_test.go
@@ -1,0 +1,99 @@
+package acquire
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"image"
+	"image/color"
+	"image/png"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"mangarr/internal/domain"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+)
+
+func TestChapterDownloadsAndThenSkipsExistingArchive(t *testing.T) {
+	t.Parallel()
+
+	var imageBytes bytes.Buffer
+	img := image.NewRGBA(image.Rect(0, 0, 1, 1))
+	img.Set(0, 0, color.Black)
+	require.NoError(t, png.Encode(&imageBytes, img))
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "image/png")
+		_, _ = w.Write(imageBytes.Bytes())
+	}))
+	defer server.Close()
+
+	source := &pageSource{pages: []domain.ImageInfo{{ImageURL: server.URL}}}
+	request := Request{
+		Source: source,
+		Manga: domain.Manga{
+			Title: "Original Title",
+		},
+		Chapter: domain.Chapter{
+			Number: domain.MustParseChapterNumber("7.1"),
+			Title:  "The Chapter",
+		},
+		DownloadDirectory: t.TempDir(),
+		NamingTemplate:    "{manga:<.>} Ch. {num}{title: - <.>}",
+		TitleOverride:     "Replacement: Title",
+	}
+
+	result, err := Chapter(t.Context(), zerolog.Nop(), request)
+	require.NoError(t, err)
+	require.Equal(t, Downloaded, result.Status)
+	require.Equal(t, "Replacement Title Ch. 7.1 - The Chapter", result.Name)
+	require.Equal(t, filepath.Join(request.DownloadDirectory, "Replacement Title", "Replacement Title Ch. 7.1 - The Chapter.cbz"), result.Path)
+	require.Equal(t, 1, source.calls)
+
+	archive, err := zip.OpenReader(result.Path)
+	require.NoError(t, err)
+	require.Len(t, archive.File, 1)
+	require.NoError(t, archive.Close())
+
+	result, err = Chapter(t.Context(), zerolog.Nop(), request)
+	require.NoError(t, err)
+	require.Equal(t, Skipped, result.Status)
+	require.Equal(t, 1, source.calls, "skip must not resolve pages")
+}
+
+func TestChapterReturnsPageResolutionErrorWithoutPublishingArchive(t *testing.T) {
+	t.Parallel()
+
+	downloadDirectory := t.TempDir()
+	request := Request{
+		Source:            &pageSource{err: context.Canceled},
+		Manga:             domain.Manga{Title: "Title"},
+		Chapter:           domain.Chapter{Number: domain.MustParseChapterNumber("2")},
+		DownloadDirectory: downloadDirectory,
+		NamingTemplate:    "Chapter {num}",
+	}
+
+	result, err := Chapter(t.Context(), zerolog.Nop(), request)
+	require.ErrorIs(t, err, context.Canceled)
+	require.NoFileExists(t, result.Path)
+
+	entries, readErr := os.ReadDir(downloadDirectory)
+	require.NoError(t, readErr)
+	require.Empty(t, entries)
+}
+
+type pageSource struct {
+	pages []domain.ImageInfo
+	err   error
+	calls int
+}
+
+func (s *pageSource) Pages(context.Context, domain.Chapter) ([]domain.ImageInfo, error) {
+	s.calls++
+	return s.pages, s.err
+}


### PR DESCRIPTION
<!-- ship-stack:start -->
## PR stack

> [!NOTE]
> This PR is part of a stack. Merge it with the full stack when ready.

Depends on:
- #106

Followed by:
- #108
<!-- ship-stack:end -->

## Why

Download and monitor independently implemented naming, existing-file checks, page resolution, image transfer, and archive creation. Policy fixes could drift between the two user flows.

## What changed

- Add one chapter-acquisition operation with explicit downloaded and skipped outcomes.
- Move title overrides, naming, archive paths, skip checks, page resolution, download, and CBZ publication into it.
- Route both commands through the shared operation.
- Add an end-to-end regression test for download, archive contents, and repeat-run skip behavior.
- Update architecture and adapter ownership documentation.

## Tests

- `go test ./...`
- `go test -race ./...`
- `go build ./...`
- `govulncheck ./...`
