### PR TITLE
chore: align container and operator docs

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # ARCHITECTURE.md
 
-Verified against code on 2026-03-25.
+Verified against code on 2026-08-07.
 
 ## Purpose
 
@@ -14,8 +14,8 @@ Verified against code on 2026-03-25.
 
 | Domain | Main entrypoints | Notes |
 | --- | --- | --- |
-| Download now | `cmd/download.go` | source selection, chapter selection, archive write |
-| Continuous monitor | `cmd/monitor.go` | config load, ticker loop, dynamic reload, latest-chapter fetch |
+| Download now | `cmd/download.go` | source discovery and chapter selection |
+| Continuous monitor | `cmd/monitor.go` | config load, reload-aware scheduler, latest-chapter selection |
 | Source integration | `internal/source/` | highest churn; mixed API and HTML scraping |
 | Chapter acquisition | `internal/acquire/`, `internal/download/`, `internal/files/` | naming, existing-file policy, page resolution, image fetch, CBZ creation |
 | Ops + packaging | `.github/workflows/release.yml`, `.goreleaser.yaml`, `ci.Dockerfile` | release binaries and multi-arch Docker images |
@@ -28,7 +28,7 @@ Verified against code on 2026-03-25.
 | Application orchestration | `cmd/`, `internal/acquire/`, `internal/config/` | compose sources, acquire chapters, concurrency, config/runtime lifecycle |
 | Core domain helpers | `internal/domain/`, `internal/parse/`, `internal/templater/`, `internal/sanitize/` | shared logic independent from any source |
 | Integration layer | `internal/source/`, `internal/sharedhttp/`, `internal/download/` | fetch remote data and retry transient failures |
-| Output + observability | `internal/files/`, `internal/logger/`, `internal/perf/`, `internal/buildinfo/` | archive write, logging, profiling, build metadata |
+| Output + observability | `internal/files/`, `internal/logger/`, `internal/perf/`, `internal/buildinfo/` | atomic archive publication, logging, profiling, build metadata |
 
 Rule: source-specific scraping logic stays in `internal/source/`. Generic retry, archive creation, and parsing stay shared.
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,19 @@ Available for:
 docker pull ghcr.io/nuxencs/mangarr:latest
 ```
 
+For Docker Compose, prepare writable host directories and start the checked-in
+sample with your user and group IDs:
+
+```bash
+mkdir -p config/mangarr downloads
+cp config.yaml config/mangarr/config.yaml
+PUID=$(id -u) PGID=$(id -g) docker compose up -d
+```
+
+The sample defaults to `./config`, `./downloads`, and the container's unprivileged
+user when the optional `DOCKERCONFDIR`, `DOWNLOADDIR`, `PUID`, or `PGID` variables
+are not set.
+
 Check the installed version:
 
 ```bash

--- a/ci.Dockerfile
+++ b/ci.Dockerfile
@@ -1,5 +1,5 @@
 # build base
-FROM --platform=$BUILDPLATFORM golang:1.26-alpine3.23 AS app-base
+FROM --platform=$BUILDPLATFORM golang:1.26.5-alpine3.23 AS app-base
 
 WORKDIR /src
 
@@ -29,12 +29,12 @@ RUN --network=none --mount=target=. \
     -o /out/bin/mangarr main.go
 
 # build runner
-FROM alpine:latest AS runner
-RUN apk add --no-cache ca-certificates curl tzdata jq tini
+FROM alpine:3.23 AS runner
+RUN apk add --no-cache ca-certificates tini tzdata
 
 LABEL org.opencontainers.image.source="https://github.com/nuxencs/mangarr" \
     org.opencontainers.image.licenses="MIT" \
-    org.opencontainers.image.base.name="alpine:latest"
+    org.opencontainers.image.base.name="alpine:3.23"
 
 ENV HOME="/config" \
     XDG_CONFIG_HOME="/config" \

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -31,7 +31,7 @@ func initRootFlags(root *cobra.Command, options *rootOptions) {
 		"config",
 		"c",
 		"",
-		"specifies the path to your config file",
+		"directory that contains config.yaml",
 	)
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -35,8 +35,8 @@ func newRootCommand(deps dependencies) *cobra.Command {
 
 Provide a configuration file using one of the following methods:
 1. Use the --config <path> or -c <path> flag.
-2. Place a config.yaml file in the default user configuration directory (e.g., ~/.config/mangarr/).
-3. Place a config.yaml file a folder inside your home directory (e.g., ~/.mangarr/).
+2. Place config.yaml in the operating system user config directory under mangarr/.
+3. Place config.yaml in ~/.mangarr/.
 4. Place a config.yaml file in the directory of the binary.
 
 For more information and examples, visit https://github.com/nuxencs/mangarr`,

--- a/config.yaml
+++ b/config.yaml
@@ -91,7 +91,7 @@ monitoredManga:
 
     # URL of the manga on Flame Comics
     #
-    manga: "https://flamecomics.xyz/series/solo-leveling-ragnarok/"
+    manga: "https://flamecomics.xyz/series/143"
 
   # Custom name you can give the entry to easily distinguish between them
   #

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,17 +1,11 @@
 services:
   mangarr:
     container_name: mangarr
-    image: ghcr.io/nuxencs/mangarr
+    image: ghcr.io/nuxencs/mangarr:latest
     restart: unless-stopped
-    user: ${PUID}:${PGID}  # UID and GID
+    user: "${PUID:-65534}:${PGID:-65534}"
     environment:
-      - MANGARR__DOWNLOAD_LOCATION=
-      - MANGARR__NAMING_TEMPLATE=
-      - MANGARR__CHECK_INTERVAL=
-      - MANGARR__LOG_LEVEL=
-      - MANGARR__LOG_PATH=
-      - MANGARR__LOG_MAX_SIZE=
-      - MANGARR__LOG_MAX_BACKUPS=
+      MANGARR__DOWNLOAD_LOCATION: /downloads
     volumes:
-      - ${DOCKERCONFDIR}/mangarr:/config  # location of the config file
-      - /path/to/directory:/path/to/directory  # download location
+      - "${DOCKERCONFDIR:-./config}/mangarr:/config"
+      - "${DOWNLOADDIR:-./downloads}:/downloads"

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1,6 +1,6 @@
 # DESIGN.md
 
-Verified against code on 2026-03-07.
+Verified against code on 2026-08-07.
 
 Use this file as the design-doc entry point. Start small, then drill down.
 

--- a/docs/PLANS.md
+++ b/docs/PLANS.md
@@ -1,6 +1,6 @@
 # PLANS.md
 
-Verified on 2026-03-07.
+Verified on 2026-08-07.
 
 Plans are first-class repo artifacts.
 
@@ -29,4 +29,5 @@ Each execution plan should capture:
 
 ## Mechanical Follow-Through
 
-This repo does not yet enforce doc freshness mechanically. Track missing linters, link checks, and doc-gardening automation in the tech debt tracker until implemented.
+CI validates Markdown links and important YAML, Compose, and GoReleaser files.
+The tech debt tracker records recurring checks that still need automation.

--- a/docs/QUALITY_SCORE.md
+++ b/docs/QUALITY_SCORE.md
@@ -1,25 +1,26 @@
 # QUALITY_SCORE.md
 
-Baseline captured on 2026-03-07.
+Assessment updated on 2026-08-07 after the reliability stack.
 
 ## Product Domains
 
 | Domain | Score | Why | Gap to close |
 | --- | --- | --- | --- |
-| Download CLI | B | clear flow, decent docs, core tests around parsing/files/download | broader end-to-end smoke coverage |
-| Monitor mode | B- | functional runtime model, config reload, logs | stronger runbook and operational checks |
-| Source adapters | C+ | broad coverage, shared helpers | high drift risk, limited regression fixtures |
-| Packaging/releases | B | GoReleaser + Docker CI in place | docs/CI ignore markdown-only drift; no doc checks |
+| Download CLI | A- | one acquisition policy, explicit outcomes, end-to-end archive coverage | live smoke coverage remains manual |
+| Monitor mode | B+ | immediate polling, validated reload snapshots, shared acquisition | formal operator runbook and health checks |
+| Source adapters | B | small return-value contract, one registry, fixture flow for every source | upstream drift still requires live verification |
+| Packaging/releases | A- | full CI gate, generated-code check, pinned lean runtime image | actions are not pinned to commit digests |
 
 ## Architecture Layers
 
 | Layer | Score | Why | Gap to close |
 | --- | --- | --- | --- |
-| CLI/orchestration | B | straightforward command layout | reduce some duplication between download and monitor selection flow |
-| Core helpers | B | cohesive small packages | more tests around edge cases and naming semantics |
-| Integration layer | C+ | shared retry and fixture seams help | source drift remains dominant reliability risk |
-| Output/observability | B- | logs and pprof exist | no formal health checklist or richer status summaries |
+| CLI/orchestration | A- | fresh command trees, one source registry, shared acquisition boundary | command coverage can expand around multi-chapter summaries |
+| Core helpers | B+ | cohesive packages, bounded concurrency, dead production code removed | naming syntax remains custom and lightly documented |
+| Integration layer | B | shared retry, cancellation, exact-host validation, offline fixtures | source drift remains the dominant reliability risk |
+| Output/observability | A- | atomic CBZ publication, explicit summaries, logs, pprof | no formal health checklist |
 
 ## Trend
 
-This is the first recorded baseline. Update scores when material behavior or verification changes land.
+The stack improved every recorded domain. Future score changes need code, test, or
+operational evidence, not documentation-only assertions.

--- a/docs/RELIABILITY.md
+++ b/docs/RELIABILITY.md
@@ -1,6 +1,6 @@
 # RELIABILITY.md
 
-Verified on 2026-03-26.
+Verified on 2026-08-07.
 
 ## Main Failure Modes
 
@@ -14,11 +14,14 @@ Verified on 2026-03-26.
 
 - shared retry policy in `internal/sharedhttp/`
 - bounded chapter, source, and image concurrency
-- skip-on-existing archive behavior
+- one shared acquisition policy for download and monitor
+- skip-on-existing archive behavior before page resolution
 - atomic archive publication after ZIP writers and files close successfully
 - optional `pprof` endpoint for runtime inspection
-- config reload without full process restart
+- immediate first monitor poll and reload-aware scheduling
+- validated, immutable config snapshots without full process restart
 - fixture-backed regression flows for every source adapter
+- CI tests, race tests, builds, vets, vulnerability scans, and repository-file checks
 
 ## Verification Expectations
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -1,6 +1,6 @@
 # SECURITY.md
 
-Verified on 2026-03-26.
+Verified on 2026-08-07.
 
 ## Trust Boundaries
 
@@ -21,9 +21,10 @@ Verified on 2026-03-26.
 - keep archive output under explicit user-selected directories
 - prefer shared HTTP code paths over ad hoc adapter-local clients
 - document new dependencies before adoption
+- scan reachable dependencies with `govulncheck` in CI
+- run the container as an unprivileged user with a pinned Alpine release line
 
 ## Gaps
 
-- no documented vuln-scanning routine beyond normal dependency hygiene
 - no dedicated egress allowlist or source isolation controls
-- no CI checks focused specifically on dependency or docs-governance risk
+- GitHub actions use version tags rather than immutable commit digests

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -111,9 +111,13 @@ logLevel: "DEBUG"
 Config lookup order:
 
 1. If `-c` is set, mangarr reads `<config-dir>/config.yaml`.
-2. `~/.config/mangarr/config.yaml`
+2. `<user-config-dir>/mangarr/config.yaml` (for example,
+   `~/.config/mangarr/config.yaml` on Linux).
 3. `~/.mangarr/config.yaml`
 4. `config.yaml` next to the binary
+
+The current working directory is not an implicit config location. Use `-c .` to
+load `./config.yaml` explicitly.
 
 Environment overrides use the `MANGARR__` prefix:
 
@@ -223,7 +227,7 @@ go tool pprof http://127.0.0.1:6060/debug/pprof/profile?seconds=30
 
 Requirements:
 
-- Go 1.24.2 or later
+- Go 1.26.5 or later
 
 ```bash
 git clone https://github.com/nuxencs/mangarr.git

--- a/docs/design-docs/core-beliefs.md
+++ b/docs/design-docs/core-beliefs.md
@@ -1,6 +1,6 @@
 # Core Beliefs
 
-Verified on 2026-03-07.
+Verified on 2026-08-07.
 
 ## Agent-First Principles
 

--- a/docs/design-docs/index.md
+++ b/docs/design-docs/index.md
@@ -1,6 +1,6 @@
 # Design Docs Index
 
-Catalog verified on 2026-03-07.
+Catalog verified on 2026-08-07.
 
 ## Catalog
 

--- a/docs/design-docs/runtime-model.md
+++ b/docs/design-docs/runtime-model.md
@@ -1,10 +1,10 @@
 # Runtime Model
 
-Verified against `cmd/download.go`, `cmd/monitor.go`, and `internal/config/config.go` on 2026-03-07.
+Verified against `cmd/download.go`, `cmd/monitor.go`, and `internal/config/config.go` on 2026-08-07.
 
 ## Commands
 
-- `download`: one-shot flow; resolves a source, selects chapters, downloads images, writes `.cbz`
+- `download`: one-shot flow; resolves a source, selects chapters, and delegates acquisition
 - `monitor`: long-running flow; loads config, watches for changes, polls sources on an interval
 - `version`: reports build metadata and latest GitHub release info
 
@@ -24,12 +24,12 @@ There is no database, queue, or remote control plane.
 - source jobs fan out per tick in `monitor`
 - image downloads fan out inside `internal/download`
 
-Semaphores cap concurrency. The code favors bounded parallelism over unbounded goroutine fan-out.
+Each layer has an explicit concurrency limit. The code favors bounded parallelism over unbounded goroutine fan-out.
 
 ## Config Lifecycle
 
 - defaults are embedded in Go structs/template text
-- config path lookup falls back through local and home-directory locations
+- config path lookup checks the user config directory, `~/.mangarr`, then the binary directory
 - env overrides use `MANGARR__` prefix
 - monitor mode publishes validated immutable config snapshots while running
 - monitored manga, naming, download location, interval, and log level reload live

--- a/docs/design-docs/source-adapters.md
+++ b/docs/design-docs/source-adapters.md
@@ -1,6 +1,6 @@
 # Source Adapters
 
-Verified against `internal/source/` on 2026-08-07.
+Verified against `internal/source/` and all live sources on 2026-08-08.
 
 All adapters implement the small `domain.Source` contract:
 

--- a/docs/exec-plans/active/README.md
+++ b/docs/exec-plans/active/README.md
@@ -1,3 +1,3 @@
 # Active Execution Plans
 
-- [Codebase reliability stack](./2026-08-07-codebase-reliability-stack.md)
+No active execution plans.

--- a/docs/exec-plans/completed/2026-08-07-codebase-reliability-stack.md
+++ b/docs/exec-plans/completed/2026-08-07-codebase-reliability-stack.md
@@ -205,3 +205,4 @@ container UID and GID.
 - `goreleaser check`
 - Docker registry manifest lookup for both pinned base images
 - GitHub Actions checks passed for stack PRs #101 through #108 before final PR publication
+- Live discovery and latest-chapter page resolution passed for all nine source adapters on 2026-08-08

--- a/docs/exec-plans/completed/2026-08-07-codebase-reliability-stack.md
+++ b/docs/exec-plans/completed/2026-08-07-codebase-reliability-stack.md
@@ -174,3 +174,34 @@ production functions under `deadcode`.
 
 Notes/risks: Test-only parse helpers remain local to the packages that need concise
 fixture setup. They are not part of the production API.
+
+## Bucket 9 - Container and documentation alignment - ALIGNED
+
+Built: Pinned the builder to Go 1.26.5 and the runtime to Alpine 3.23, removed
+unused runtime packages, added safe Compose defaults, implemented the documented
+operating-system and binary config lookup order, and refreshed architecture,
+reliability, security, quality, operator, usage, and debt documentation.
+
+Serves goal/decision because: Release inputs now match the verified toolchain and
+supported runtime behavior, and users and maintainers have one current operating
+contract.
+
+Notes/risks: The local Docker daemon was unavailable. Registry manifest lookup
+confirmed both base image tags, and GitHub's multi-architecture build is the image
+build gate. Default bind-mount directories must be writable by the configured
+container UID and GID.
+
+## Final Verification
+
+- `go test ./...`
+- `go test -race ./...`
+- `go build ./...`
+- `go vet ./...`
+- `govulncheck ./...`
+- `deadcode ./...`
+- `go mod tidy -diff`
+- `docker compose config --quiet`
+- `yamllint .github .goreleaser.yaml config.yaml docker-compose.yml`
+- `goreleaser check`
+- Docker registry manifest lookup for both pinned base images
+- GitHub Actions checks passed for stack PRs #101 through #108 before final PR publication

--- a/docs/exec-plans/completed/README.md
+++ b/docs/exec-plans/completed/README.md
@@ -4,4 +4,10 @@ Completed plans kept in-repo:
 
 - [2026-03-07-chapter-number-refactor.md](./2026-03-07-chapter-number-refactor.md)
 - [2026-03-07-doc-knowledge-base-restructure.md](./2026-03-07-doc-knowledge-base-restructure.md)
+- [2026-03-22-asurascans-provider-repair.md](./2026-03-22-asurascans-provider-repair.md)
+- [2026-03-25-weebcentral-http-image-extraction.md](./2026-03-25-weebcentral-http-image-extraction.md)
+- [2026-03-27-user-facing-readme-rewrite.md](./2026-03-27-user-facing-readme-rewrite.md)
+- [2026-05-19-atsumaru-provider.md](./2026-05-19-atsumaru-provider.md)
+- [2026-05-19-comix-deprecation.md](./2026-05-19-comix-deprecation.md)
+- [2026-08-07-codebase-reliability-stack.md](./2026-08-07-codebase-reliability-stack.md)
 - [2026-08-07-comix-protocol-restoration.md](./2026-08-07-comix-protocol-restoration.md)

--- a/docs/exec-plans/tech-debt-tracker.md
+++ b/docs/exec-plans/tech-debt-tracker.md
@@ -1,11 +1,10 @@
 # Tech Debt Tracker
 
-Updated on 2026-03-07.
+Updated on 2026-08-07.
 
 | Area | Debt | Impact | Next step |
 | --- | --- | --- | --- |
-| Docs governance | no doc link/index freshness checks in CI | docs can drift silently | add markdown/link/structure validation job |
 | Doc gardening | no recurring stale-doc scan | dead docs accumulate | add scheduled doc-gardening automation |
-| Source reliability | limited adapter regression fixtures | scraper drift reaches users faster | add adapter-focused fixture or smoke-test harness |
+| Source reliability | no automated live-source smoke suite | upstream drift can pass stored fixtures | design a respectful scheduled smoke check |
 | Runtime observability | no documented health checklist for long-running monitor ops | failures harder to triage | add operator runbook and smoke checklist |
 | Generated docs | `docs/generated/` is placeholder only | generated surfaces can rot later | define generation scripts once a generated artifact exists |

--- a/docs/product-specs/index.md
+++ b/docs/product-specs/index.md
@@ -1,6 +1,6 @@
 # Product Specs Index
 
-Catalog verified on 2026-03-07.
+Catalog verified on 2026-08-07.
 
 ## Specs
 

--- a/docs/product-specs/monitoring-operator.md
+++ b/docs/product-specs/monitoring-operator.md
@@ -1,6 +1,6 @@
 # Monitoring Operator
 
-Verified against `cmd/monitor.go` and `internal/config/config.go` on 2026-03-26.
+Verified against `cmd/monitor.go` and `internal/config/config.go` on 2026-08-07.
 
 ## User Goal
 
@@ -21,3 +21,4 @@ Run `mangarr monitor` unattended and trust it to fetch new chapters without cons
 - source-specific runtime requirements stay documented when they appear
 - monitor checks configured manga once at startup before waiting for the interval
 - invalid reloads keep the last valid config snapshot active
+- config lookup follows the documented operating-system and binary locations

--- a/docs/product-specs/new-user-onboarding.md
+++ b/docs/product-specs/new-user-onboarding.md
@@ -1,6 +1,6 @@
 # New User Onboarding
 
-Verified against `README.md` and `docs/USAGE.md` on 2026-03-27.
+Verified against `README.md` and `docs/USAGE.md` on 2026-08-07.
 
 ## User Goal
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -243,19 +243,47 @@ func resolveConfigFile(configPath string) (string, error) {
 		return filepath.Join(cleanPath, "config.yaml"), nil
 	}
 
-	locations := []string{
-		"./config.yaml",
-		"$HOME/.config/mangarr/config.yaml",
-		"$HOME/.mangarr/config.yaml",
+	var userConfigDir, homeDir, executablePath string
+	if path, err := os.UserConfigDir(); err == nil {
+		userConfigDir = path
 	}
-	for _, location := range locations {
-		expanded := os.ExpandEnv(location)
-		if _, err := os.Stat(expanded); err == nil {
-			return expanded, nil
-		}
+	if path, err := os.UserHomeDir(); err == nil {
+		homeDir = path
+	}
+	if path, err := os.Executable(); err == nil {
+		executablePath = path
 	}
 
-	return "", fmt.Errorf("could not find config file")
+	locations := defaultConfigLocations(userConfigDir, homeDir, executablePath)
+	if location, ok := firstExistingConfig(locations); ok {
+		return location, nil
+	}
+
+	return "", fmt.Errorf("could not find config file in default locations")
+}
+
+func firstExistingConfig(locations []string) (string, bool) {
+	for _, location := range locations {
+		info, err := os.Stat(location)
+		if err == nil && !info.IsDir() {
+			return location, true
+		}
+	}
+	return "", false
+}
+
+func defaultConfigLocations(userConfigDir, homeDir, executablePath string) []string {
+	locations := make([]string, 0, 3)
+	if userConfigDir != "" {
+		locations = append(locations, filepath.Join(userConfigDir, "mangarr", "config.yaml"))
+	}
+	if homeDir != "" {
+		locations = append(locations, filepath.Join(homeDir, ".mangarr", "config.yaml"))
+	}
+	if executablePath != "" {
+		locations = append(locations, filepath.Join(filepath.Dir(executablePath), "config.yaml"))
+	}
+	return locations
 }
 
 func (c *AppConfig) loadSnapshot() (*domain.Config, error) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3,12 +3,61 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"slices"
 	"testing"
 	"time"
 
 	"mangarr/internal/domain"
 	"mangarr/internal/logger"
 )
+
+func TestDefaultConfigLocationsFollowDocumentedOrder(t *testing.T) {
+	t.Parallel()
+
+	locations := defaultConfigLocations(
+		filepath.Join("root", "user-config"),
+		filepath.Join("root", "home"),
+		filepath.Join("root", "bin", "mangarr"),
+	)
+	want := []string{
+		filepath.Join("root", "user-config", "mangarr", "config.yaml"),
+		filepath.Join("root", "home", ".mangarr", "config.yaml"),
+		filepath.Join("root", "bin", "config.yaml"),
+	}
+	if !slices.Equal(locations, want) {
+		t.Fatalf("config locations = %v, want %v", locations, want)
+	}
+}
+
+func TestDefaultConfigLocationsOmitUnavailableDirectories(t *testing.T) {
+	t.Parallel()
+
+	locations := defaultConfigLocations("", "", filepath.Join("root", "bin", "mangarr"))
+	want := []string{filepath.Join("root", "bin", "config.yaml")}
+	if !slices.Equal(locations, want) {
+		t.Fatalf("config locations = %v, want %v", locations, want)
+	}
+}
+
+func TestFirstExistingConfigUsesLocationOrder(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	missing := filepath.Join(root, "missing", "config.yaml")
+	first := filepath.Join(root, "first.yaml")
+	second := filepath.Join(root, "second.yaml")
+	if err := os.WriteFile(first, []byte("first"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(second, []byte("second"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, ok := firstExistingConfig([]string{missing, first, second})
+	if !ok || got != first {
+		t.Fatalf("first existing config = %q, %v; want %q, true", got, ok, first)
+	}
+}
 
 func TestLoadRejectsInvalidCheckInterval(t *testing.T) {
 	dir := t.TempDir()


### PR DESCRIPTION
<!-- ship-stack:start -->
## PR stack

> [!NOTE]
> This PR is part of a stack. Merge it with the full stack when ready.

Depends on:
- #108
<!-- ship-stack:end -->

## Why

Container defaults, config lookup, Go requirements, and quality documentation did not match the verified runtime behavior.

## What changed

- Pin the builder to Go 1.26.5 and the runner to Alpine 3.23.
- Remove unused runtime packages and keep unprivileged execution.
- Make the Compose sample usable without unset-variable interpolation or blank config overrides.
- Implement and test the documented user-config, home, and binary config lookup order.
- Clarify that `--config` accepts a directory.
- Refresh the stale Flame Comics sample with its current numeric series URL.
- Refresh architecture, reliability, security, quality, usage, product, plan, and debt documentation.
- Close and archive the reliability execution plan.

## Tests

- `go test ./...`
- `go test -race ./...`
- `go build ./...`
- `go vet ./...`
- `govulncheck ./...`
- `deadcode ./...`
- `go mod tidy -diff`
- `go generate ./...`
- `docker compose config --quiet`
- `yamllint .github .goreleaser.yaml config.yaml docker-compose.yml`
- `goreleaser check`
- Verified both pinned base-image manifests.
- Live discovery and latest-page resolution passed for all nine adapters on 2026-08-08.

The local Docker daemon was unavailable. GitHub multi-architecture builds provided the container build gate.
