### PR TITLE
fix(config): keep reload watcher alive across replacements

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1,6 +1,6 @@
 # Usage Reference
 
-Verified against CLI help and config/runtime code on 2026-08-07.
+Verified against CLI help and config/runtime code on 2026-08-09.
 
 Use this doc when the root README is not enough and you need command, config, or operator detail.
 
@@ -134,7 +134,9 @@ Environment overrides use the `MANGARR__` prefix:
 Monitor checks all configured manga once at startup. It then waits for the check
 interval. Changes to monitored manga, naming, download location, check interval,
 and log level reload while monitor runs. Environment overrides are reapplied to
-each reload. Changes to pprof and log file output settings require a restart.
+each reload. Atomic replacement and delete-then-recreate saves remain watched.
+An invalid, incomplete, or temporarily missing config keeps the last valid
+settings active. Changes to pprof and log file output settings require a restart.
 
 ### `version`
 

--- a/docs/design-docs/runtime-model.md
+++ b/docs/design-docs/runtime-model.md
@@ -1,6 +1,6 @@
 # Runtime Model
 
-Verified against `cmd/download.go`, `cmd/monitor.go`, and `internal/config/config.go` on 2026-08-07.
+Verified against `cmd/download.go`, `cmd/monitor.go`, and `internal/config/config.go` on 2026-08-09.
 
 ## Commands
 
@@ -32,6 +32,8 @@ Each layer has an explicit concurrency limit. The code favors bounded parallelis
 - config path lookup checks the user config directory, `~/.mangarr`, then the binary directory
 - env overrides use `MANGARR__` prefix
 - monitor mode publishes validated immutable config snapshots while running
+- monitor mode watches the config parent directory, so atomic replacement and delete-then-recreate saves do not stop reloads
+- invalid, incomplete, or temporarily missing config files keep the last valid snapshot active
 - monitored manga, naming, download location, interval, and log level reload live
 - pprof and log output destinations require a restart
 

--- a/docs/product-specs/monitoring-operator.md
+++ b/docs/product-specs/monitoring-operator.md
@@ -1,6 +1,6 @@
 # Monitoring Operator
 
-Verified against `cmd/monitor.go` and `internal/config/config.go` on 2026-08-07.
+Verified against `cmd/monitor.go` and `internal/config/config.go` on 2026-08-09.
 
 ## User Goal
 
@@ -21,4 +21,5 @@ Run `mangarr monitor` unattended and trust it to fetch new chapters without cons
 - source-specific runtime requirements stay documented when they appear
 - monitor checks configured manga once at startup before waiting for the interval
 - invalid reloads keep the last valid config snapshot active
+- atomic replacement and delete-then-recreate saves do not stop future reloads
 - config lookup follows the documented operating-system and binary locations

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.26.5
 require (
 	github.com/PuerkitoBio/goquery v1.12.0
 	github.com/avast/retry-go v3.0.0+incompatible
+	github.com/fsnotify/fsnotify v1.9.0
 	github.com/gocolly/colly/v2 v2.3.0
 	github.com/google/uuid v1.6.0
 	github.com/knadh/koanf/parsers/yaml v1.1.0
@@ -28,7 +29,6 @@ require (
 	github.com/bits-and-blooms/bitset v1.24.4 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fatih/structs v1.1.0 // indirect
-	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
 	github.com/gobwas/glob v0.2.3 // indirect
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,12 +8,14 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
 	"mangarr/internal/domain"
 	"mangarr/internal/logger"
 
+	"github.com/fsnotify/fsnotify"
 	"github.com/knadh/koanf/parsers/yaml"
 	"github.com/knadh/koanf/providers/file"
 	"github.com/knadh/koanf/providers/structs"
@@ -201,6 +203,7 @@ type AppConfig struct {
 	current    atomic.Pointer[domain.Config]
 	configFile string
 	version    string
+	watcher    *fsnotify.Watcher
 }
 
 func Load(configPath string, version string) (*AppConfig, error) {
@@ -401,19 +404,88 @@ func cloneConfig(cfg domain.Config) domain.Config {
 	return clone
 }
 
+const configReloadDebounceDelay = 100 * time.Millisecond
+
+func (c *AppConfig) watchConfigFile(log *logger.DefaultLogger, onChange func()) error {
+	watchedPath := filepath.Clean(c.configFile)
+	realPath, err := filepath.EvalSymlinks(watchedPath)
+	if err != nil {
+		return err
+	}
+	realPath = filepath.Clean(realPath)
+
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return err
+	}
+	if err := watcher.Add(filepath.Dir(watchedPath)); err != nil {
+		_ = watcher.Close()
+		return err
+	}
+	c.watcher = watcher
+
+	go func() {
+		for {
+			select {
+			case event, ok := <-watcher.Events:
+				if !ok {
+					return
+				}
+
+				eventPath := filepath.Clean(event.Name)
+				currentRealPath, err := filepath.EvalSymlinks(watchedPath)
+				if err != nil {
+					if os.IsNotExist(err) {
+						onWatchedFile := eventPath == watchedPath || eventPath == realPath
+						if onWatchedFile && event.Has(fsnotify.Remove|fsnotify.Rename) {
+							onChange()
+						}
+					} else {
+						log.Error().Err(err).Msg("error resolving watched config file")
+					}
+					continue
+				}
+				currentRealPath = filepath.Clean(currentRealPath)
+
+				onWatchedFile := eventPath == watchedPath || eventPath == realPath
+				targetChanged := currentRealPath != realPath
+				if targetChanged || (onWatchedFile && event.Has(fsnotify.Create|fsnotify.Write)) {
+					realPath = currentRealPath
+					onChange()
+				}
+			case watchErr, ok := <-watcher.Errors:
+				if !ok {
+					return
+				}
+				log.Error().Err(watchErr).Msg("error watching config file")
+			}
+		}
+	}()
+
+	return nil
+}
+
 func (c *AppConfig) DynamicReload(log *logger.DefaultLogger) (<-chan struct{}, error) {
 	reloaded := make(chan struct{}, 1)
-	f := file.Provider(c.configFile)
+	var (
+		reloadGeneration atomic.Uint64
+		reloadMu         sync.Mutex
+	)
 
-	err := f.Watch(func(_ any, watchErr error) {
-		if watchErr != nil {
-			log.Error().Err(watchErr).Msg("error watching config file")
+	reloadIfLatest := func(generation uint64) {
+		if generation != reloadGeneration.Load() {
+			return
+		}
+
+		reloadMu.Lock()
+		defer reloadMu.Unlock()
+		if generation != reloadGeneration.Load() {
 			return
 		}
 
 		snapshot, err := c.loadSnapshot()
 		if err != nil {
-			log.Error().Err(err).Msg("config reload rejected")
+			log.Error().Err(err).Msg("config reload rejected; keeping previous config")
 			return
 		}
 
@@ -424,8 +496,16 @@ func (c *AppConfig) DynamicReload(log *logger.DefaultLogger) (<-chan struct{}, e
 		default:
 		}
 		log.Debug().Msg("config file reloaded")
-	})
-	if err != nil {
+	}
+
+	scheduleReload := func() {
+		generation := reloadGeneration.Add(1)
+		time.AfterFunc(configReloadDebounceDelay, func() {
+			reloadIfLatest(generation)
+		})
+	}
+
+	if err := c.watchConfigFile(log, scheduleReload); err != nil {
 		return nil, fmt.Errorf("watching config file %s: %w", c.configFile, err)
 	}
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -110,6 +110,11 @@ checkInterval: 15
 	if err != nil {
 		t.Fatalf("watch config: %v", err)
 	}
+	t.Cleanup(func() {
+		if err := cfg.watcher.Close(); err != nil {
+			t.Errorf("close config watcher: %v", err)
+		}
+	})
 
 	writeTestConfig(t, dir, `downloadLocation: "`+dir+`"
 checkInterval: 2
@@ -131,6 +136,176 @@ monitoredManga:
 	}
 	if got.MonitoredManga["One Piece"].Source != "tcbscans" {
 		t.Fatalf("monitored manga not reloaded: %#v", got.MonitoredManga)
+	}
+}
+
+func TestDynamicReloadSurvivesRenameAndRecreateSave(t *testing.T) {
+	dir := t.TempDir()
+	writeTestConfig(t, dir, `downloadLocation: "`+dir+`"
+checkInterval: 15
+`)
+
+	cfg, err := Load(dir, "test")
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	snapshot := cfg.Snapshot()
+	reloads, err := cfg.DynamicReload(logger.New(&snapshot))
+	if err != nil {
+		t.Fatalf("watch config: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := cfg.watcher.Close(); err != nil {
+			t.Errorf("close config watcher: %v", err)
+		}
+	})
+
+	configFile := filepath.Join(dir, "config.yaml")
+	if err := os.Rename(configFile, configFile+".backup"); err != nil {
+		t.Fatalf("rename config: %v", err)
+	}
+	time.Sleep(200 * time.Millisecond)
+
+	writeTestConfig(t, dir, `downloadLocation: "`+dir+`"
+checkInterval: 2
+`)
+	select {
+	case <-reloads:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for reload after rename-and-recreate save")
+	}
+	if got := cfg.Snapshot().CheckInterval; got != 2 {
+		t.Fatalf("check interval = %s, want 2", got)
+	}
+
+	writeTestConfig(t, dir, `downloadLocation: "`+dir+`"
+checkInterval: 3
+`)
+	select {
+	case <-reloads:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for reload after the next save")
+	}
+	if got := cfg.Snapshot().CheckInterval; got != 3 {
+		t.Fatalf("check interval = %s, want 3", got)
+	}
+}
+
+func TestDynamicReloadDebouncesIncompleteWrites(t *testing.T) {
+	dir := t.TempDir()
+	writeTestConfig(t, dir, `downloadLocation: "`+dir+`"
+checkInterval: 15
+`)
+
+	cfg, err := Load(dir, "test")
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	snapshot := cfg.Snapshot()
+	reloads, err := cfg.DynamicReload(logger.New(&snapshot))
+	if err != nil {
+		t.Fatalf("watch config: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := cfg.watcher.Close(); err != nil {
+			t.Errorf("close config watcher: %v", err)
+		}
+	})
+
+	configFile := filepath.Join(dir, "config.yaml")
+	writer, err := os.OpenFile(configFile, os.O_WRONLY|os.O_TRUNC, 0)
+	if err != nil {
+		t.Fatalf("truncate config: %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close truncated config: %v", err)
+	}
+	time.Sleep(configReloadDebounceDelay / 4)
+
+	select {
+	case <-reloads:
+		t.Fatal("published a reload while the config file was incomplete")
+	case <-time.After(configReloadDebounceDelay / 2):
+	}
+	if got := cfg.Snapshot().CheckInterval; got != 15 {
+		t.Fatalf("check interval = %s, want previous value 15", got)
+	}
+
+	writeTestConfig(t, dir, `downloadLocation: "`+dir+`"
+checkInterval: 2
+`)
+	select {
+	case <-reloads:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for completed config reload")
+	}
+	time.Sleep(2 * configReloadDebounceDelay)
+	select {
+	case <-reloads:
+		t.Fatal("published a duplicate reload for one completed save")
+	default:
+	}
+	if got := cfg.Snapshot().CheckInterval; got != 2 {
+		t.Fatalf("check interval = %s, want 2", got)
+	}
+}
+
+func TestDynamicReloadFollowsReplacedConfigSymlink(t *testing.T) {
+	dir := t.TempDir()
+	firstTarget := filepath.Join(dir, "config-first.yaml")
+	secondTarget := filepath.Join(dir, "config-second.yaml")
+	configFile := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(firstTarget, []byte(`downloadLocation: "`+dir+`"
+checkInterval: 15
+`), 0o644); err != nil {
+		t.Fatalf("write first config target: %v", err)
+	}
+	if err := os.WriteFile(secondTarget, []byte(`downloadLocation: "`+dir+`"
+checkInterval: 2
+`), 0o644); err != nil {
+		t.Fatalf("write second config target: %v", err)
+	}
+	if err := os.Symlink(firstTarget, configFile); err != nil {
+		t.Skipf("config symlinks are unavailable: %v", err)
+	}
+	nextSymlink := configFile + ".next"
+	if err := os.Symlink(secondTarget, nextSymlink); err != nil {
+		t.Fatalf("create replacement config symlink: %v", err)
+	}
+
+	cfg := &AppConfig{configFile: configFile, version: "test"}
+	snapshot, err := cfg.loadSnapshot()
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	cfg.current.Store(snapshot)
+	reloads, err := cfg.DynamicReload(logger.New(snapshot))
+	if err != nil {
+		t.Fatalf("watch config: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := cfg.watcher.Close(); err != nil {
+			t.Errorf("close config watcher: %v", err)
+		}
+	})
+
+	time.Sleep(configReloadDebounceDelay)
+	if err := os.Rename(nextSymlink, configFile); err != nil {
+		t.Fatalf("replace config symlink: %v", err)
+	}
+	if err := os.WriteFile(secondTarget, []byte(`downloadLocation: "`+dir+`"
+checkInterval: 2
+`), 0o644); err != nil {
+		t.Fatalf("update replacement config target: %v", err)
+	}
+
+	select {
+	case <-reloads:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for reload after config symlink replacement")
+	}
+	if got := cfg.Snapshot().CheckInterval; got != 2 {
+		t.Fatalf("check interval = %s, want 2", got)
 	}
 }
 


### PR DESCRIPTION
## Problem

Vim can save `config.yaml` by temporarily renaming the original file and creating a replacement. The koanf file provider resolves the path during that gap, reports an `lstat` error, and permanently stops its watch loop. Later valid saves do not reload Mangarr's monitor configuration.

The failure was reproduced in a focused regression test before the fix.

## Fix

Watch the configuration parent directory directly with fsnotify while keeping koanf for parsing and loading. Removal now rejects that reload and keeps the previous snapshot active. Recreation, later writes, atomic replacements, and symlink target changes continue to reload normally.

A short debounce prevents incomplete writes and duplicate event bursts from publishing transient snapshots. Existing environment overrides, validation, monitor scheduling, and restart-only settings remain unchanged. Operator and runtime documentation now describe the recovery behavior.

## Tests

- Added regression coverage for removal, recreation, and a subsequent save.
- Added incomplete-write debounce and duplicate reload coverage.
- Added replaced configuration symlink coverage.
- Ran the reload tests 10 consecutive times and ran the complete suite with the race detector.
- Ran 10 real Vim atomic saves against `mangarr monitor` in Linux. All 10 reloaded with no watcher or reload errors.
