### PR TITLE
perf: reduce download processing overhead

### DIFF
--- a/cmd/download.go
+++ b/cmd/download.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"slices"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"mangarr/internal/acquire"
@@ -94,11 +95,14 @@ func newDownloadCommand(options *downloadOptions) *cobra.Command {
 			results := make(chan chapterResult, len(selectedChapterNumbers))
 
 			limit := make(chan struct{}, maxConcurrentChapterProcesses)
+			var queuedChapters atomic.Int64
+			queuedChapters.Store(int64(len(selectedChapterNumbers)))
 			var wg sync.WaitGroup
 
 			for _, chapterNumber := range selectedChapterNumbers {
 				wg.Go(func() {
 					limit <- struct{}{}
+					queuedChapters.Add(-1)
 
 					result := chapterResult{
 						chapterNumber: chapterNumber,
@@ -107,7 +111,8 @@ func newDownloadCommand(options *downloadOptions) *cobra.Command {
 					shouldDelay := true
 
 					defer func() {
-						if shouldDelay {
+						// Keep the cooldown only when another chapter is waiting for this slot.
+						if shouldDelay && queuedChapters.Load() > 0 {
 							time.Sleep(chapterDelay)
 						}
 

--- a/internal/source/comix_image.go
+++ b/internal/source/comix_image.go
@@ -48,7 +48,8 @@ func (comixImageProcessor) Process(headers http.Header, reader io.Reader, writer
 	if err != nil {
 		return err
 	}
-	if err := png.Encode(writer, result); err != nil {
+	encoder := png.Encoder{CompressionLevel: png.BestSpeed}
+	if err := encoder.Encode(writer, result); err != nil {
 		return fmt.Errorf("encoding descrambled Comix image: %w", err)
 	}
 


### PR DESCRIPTION
## Problem

Successful single downloads and the final multi-chapter batch retained a two-second cooldown after all useful work was complete. Comix reconstruction also used the default lossless PNG compression level, although encoding dominated the measured processing cost.

## Change

Keep the chapter cooldown only while another chapter waits for a processing slot. Encode reconstructed Comix pages with the lossless PNG best-speed setting. Source request concurrency and decoded image pixels remain unchanged.

## Results

- Removes the fixed two-second completion delay from single downloads and the final batch.
- Reduces a synthetic 1200 x 1800 Comix page transform from about 199 ms to 146 ms on an Apple M4 Pro.
- Increases the synthetic PNG size by about 3 percent with identical decoded pixels.

## Tests

- Existing Comix reconstruction coverage compares every decoded output pixel with the original.
- Race-enabled package coverage exercises the queued chapter counter.